### PR TITLE
Fix(crm): Handle tags for Contact export

### DIFF
--- a/src/contacts/ContactList.tsx
+++ b/src/contacts/ContactList.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-anonymous-default-export */
 import { Card, LinearProgress, Stack } from '@mui/material';
 import jsonExport from 'jsonexport/dist';
-import type { Exporter } from 'react-admin';
+import type { Exporter, Identifier, RaRecord } from 'react-admin';
 import {
     BulkActionsToolbar,
     BulkDeleteButton,
@@ -87,14 +87,23 @@ const ContactListActions = () => (
     </TopToolbar>
 );
 
-const exporter: Exporter<Contact> = async (records, fetchRelatedRecords) => {
+const exporter: Exporter<Contact> = async (
+    records,
+    fetchRelatedRecords,
+    dataProvider
+) => {
     const companies = await fetchRelatedRecords<Company>(
         records,
         'company_id',
         'companies'
     );
     const sales = await fetchRelatedRecords<Sale>(records, 'sales_id', 'sales');
-    const tags = await fetchRelatedRecords<Tag>(records, 'tags', 'tags');
+    const tagsIds = getRelatedIds(records, 'tags');
+    const tags = await dataProvider.getList<Tag>('tags', {
+        filter: { 'id@in': `(${tagsIds.flat()})` },
+        pagination: { page: 1, perPage: 1000 },
+        sort: { field: 'name', order: 'ASC' },
+    });
 
     const contacts = records.map(contact => ({
         ...contact,
@@ -102,9 +111,24 @@ const exporter: Exporter<Contact> = async (records, fetchRelatedRecords) => {
         sales: `${sales[contact.sales_id].first_name} ${
             sales[contact.sales_id].last_name
         }`,
-        tags: contact.tags.map(tagId => tags[tagId].name).join(', '),
+        tags: contact.tags
+            .map(tagId => tags.data.find(tag => tag.id === tagId)?.name)
+            .join(', '),
     }));
     return jsonExport(contacts, {}, (_err: any, csv: string) => {
         downloadCSV(csv, 'contacts');
     });
 };
+
+export const getRelatedIds = (
+    records: RaRecord[],
+    field: string
+): Identifier[] =>
+    Array.from(
+        new Set(
+            records
+                .filter(record => record[field] != null)
+                .map(record => record[field])
+                .reduce((ids, value) => ids.concat(value), [])
+        )
+    );


### PR DESCRIPTION
## Problem

In Atomic CRM, Contact Export not possible due to tag storage format. 

## Solution

Using an operator in. For demo we still use an `eq` for FakeRest.
