### PR TITLE
Feat(dataProvider): Add supabase to fakerest filter adapter

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,3 +13,4 @@ _Describe the steps required to test the changes_
 ## Additional Checks
 
 - [ ] The **documentation** is up to date
+- [ ] Tested with **fakerest** provider (see [related documentation](../doc/data-providers.md))

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
     lint:
-        name: 🔎 ESLint
+        name: 🔬 ESLint
         runs-on: ubuntu-latest
         timeout-minutes: 10
         if: ${{ !github.event.pull_request.draft || github.event_name == 'push' }}
@@ -44,6 +44,28 @@ jobs:
                   eslint_args: "**/*.{mjs,ts,tsx}"
                   prettier: true
                   prettier_args: "--config ./.prettierrc.mjs \"**/*.{js,json,ts,tsx,css,md,html}\""
+
+    test:
+        name: 🔎 Test
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        if: ${{ !github.event.pull_request.draft || github.event_name == 'push' }}
+        steps:
+            - name: 📥 Checkout repo
+              uses: actions/checkout@v4
+
+            - name: ⚙️ Setup node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+                  cache: npm
+
+            - name: 📥 Download deps
+              run: npm install
+
+            - name: 🔎 Test
+              run: make test-ci
+
 
     build:
         name: 🔨 Build

--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ Note: It will apply migrations and deploy edge functions.
 
 You can then access the app via [`http://localhost:3000/`](http://localhost:3000/).
 
+## Testing
+
+You can run unit test using the following command:
+```sh
+make test
+# or 
+npm test
+```
 
 ## GitHub Actions
 

--- a/doc/data-providers.md
+++ b/doc/data-providers.md
@@ -1,0 +1,20 @@
+# Data Providers
+
+This project supports two data providers:
+- A [supabase data provider](../src/providers/supabase/) (default)
+- A [fakerest data provider](../src/providers/fakerest/)
+
+## Supabase Data Provider
+
+This is the default data provider for the CRM demo. For local development, it binds to a local supabase instance.
+
+## FakeRest Data provider
+
+This data provider is used in the [React Admin CRM demo](https://marmelab.com/react-admin-crm/) and can also be used to test
+local development with generated data.
+
+## Filters
+
+The list filters used in this project MUST follow the [`ra-data-postgrest`](https://github.com/raphiniert-com/ra-data-postgrest) convention. The filters are then mapped at runtime to the fakerest filters.
+
+If a filter is not supported by the transformer, you can add new filter adapters in the [`supabaseAdapter` ](../src/providers/fakerest/internal/supabaseAdapter.ts) file.

--- a/makefile
+++ b/makefile
@@ -39,6 +39,12 @@ supabase-deploy:
 	npx supabase db push
 	npx supabase functions deploy
 
+test:
+	npm test
+
+test-ci:
+	CI=1 npm test
+
 lint:
 	npm run lint:check
 	npm run prettier:check

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
                 "lodash": "~4.17.5",
                 "papaparse": "^5.4.1",
                 "prop-types": "^15.8.1",
+                "ra-data-fakerest": "^5.1.1",
                 "ra-supabase": "^3.0.0",
                 "react": "^18.2.0",
                 "react-admin": "^5.1.0",
@@ -60,6 +61,7 @@
                 "supabase": "^1.136.3",
                 "typescript": "^5.3.3",
                 "vite": "^5.0.12",
+                "vitest": "^2.0.5",
                 "web-vitals": "^4.2.2"
             }
         },
@@ -4269,6 +4271,87 @@
                 "vite": "^4.2.0 || ^5.0.0"
             }
         },
+        "node_modules/@vitest/expect": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.0.5.tgz",
+            "integrity": "sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA==",
+            "dev": true,
+            "dependencies": {
+                "@vitest/spy": "2.0.5",
+                "@vitest/utils": "2.0.5",
+                "chai": "^5.1.1",
+                "tinyrainbow": "^1.2.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.0.5.tgz",
+            "integrity": "sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ==",
+            "dev": true,
+            "dependencies": {
+                "tinyrainbow": "^1.2.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.0.5.tgz",
+            "integrity": "sha512-TfRfZa6Bkk9ky4tW0z20WKXFEwwvWhRY+84CnSEtq4+3ZvDlJyY32oNTJtM7AW9ihW90tX/1Q78cb6FjoAs+ig==",
+            "dev": true,
+            "dependencies": {
+                "@vitest/utils": "2.0.5",
+                "pathe": "^1.1.2"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.0.5.tgz",
+            "integrity": "sha512-SgCPUeDFLaM0mIUHfaArq8fD2WbaXG/zVXjRupthYfYGzc8ztbFbu6dUNOblBG7XLMR1kEhS/DNnfCZ2IhdDew==",
+            "dev": true,
+            "dependencies": {
+                "@vitest/pretty-format": "2.0.5",
+                "magic-string": "^0.30.10",
+                "pathe": "^1.1.2"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/spy": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.0.5.tgz",
+            "integrity": "sha512-c/jdthAhvJdpfVuaexSrnawxZz6pywlTPe84LUB2m/4t3rl2fTo9NFGBG4oWgaD+FTgDDV8hJ/nibT7IfH3JfA==",
+            "dev": true,
+            "dependencies": {
+                "tinyspy": "^3.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.0.5.tgz",
+            "integrity": "sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==",
+            "dev": true,
+            "dependencies": {
+                "@vitest/pretty-format": "2.0.5",
+                "estree-walker": "^3.0.3",
+                "loupe": "^3.1.1",
+                "tinyrainbow": "^1.2.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
         "node_modules/@zeit/schemas": {
             "version": "2.36.0",
             "resolved": "https://registry.npmjs.org/@zeit/schemas/-/schemas-2.36.0.tgz",
@@ -4611,6 +4694,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/ast-types-flow": {
@@ -4975,6 +5067,15 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/cac": {
+            "version": "6.7.14",
+            "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+            "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/call-bind": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
@@ -5032,6 +5133,22 @@
                 }
             ]
         },
+        "node_modules/chai": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-5.1.1.tgz",
+            "integrity": "sha512-pT1ZgP8rPNqUgieVaEY+ryQr6Q4HXNg8Ei9UnLUrjN4IA7dvQC5JB+/kxVcPNDHyBcc/26CXPkbNzq3qwrOEKA==",
+            "dev": true,
+            "dependencies": {
+                "assertion-error": "^2.0.1",
+                "check-error": "^2.1.1",
+                "deep-eql": "^5.0.1",
+                "loupe": "^3.1.0",
+                "pathval": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/chalk": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -5066,6 +5183,15 @@
             "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
             "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
             "dev": true
+        },
+        "node_modules/check-error": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+            "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 16"
+            }
         },
         "node_modules/chownr": {
             "version": "3.0.0",
@@ -5747,6 +5873,15 @@
             "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
             "engines": {
                 "node": ">=0.10"
+            }
+        },
+        "node_modules/deep-eql": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+            "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/deep-equal": {
@@ -6722,6 +6857,15 @@
                 "node": ">=4.0"
             }
         },
+        "node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
         "node_modules/esutils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -6789,6 +6933,14 @@
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/fakerest": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/fakerest/-/fakerest-4.1.1.tgz",
+            "integrity": "sha512-GPF+MQQI4GqlSK0yYUjX/LmXyzAxmMMIPqoRz0rF8UVauJLs1gZEvGzhWCJD9RkLiQQK86wVm0A/Kig3xgChIQ==",
+            "dependencies": {
+                "lodash": "^4.17.21"
             }
         },
         "node_modules/fast-deep-equal": {
@@ -7149,6 +7301,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/get-func-name": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+            "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+            "dev": true,
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/get-intrinsic": {
@@ -9032,6 +9193,15 @@
                 "loose-envify": "cli.js"
             }
         },
+        "node_modules/loupe": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.1.tgz",
+            "integrity": "sha512-edNu/8D5MKVfGVFRhFf8aAxiTM6Wumfz5XsaatSxlD3w4R1d/WEKUTydCdPGbl9K7QG/Ca3GnDV2sIKIpXRQcw==",
+            "dev": true,
+            "dependencies": {
+                "get-func-name": "^2.0.1"
+            }
+        },
         "node_modules/lru-cache": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -9049,6 +9219,15 @@
             "peer": true,
             "bin": {
                 "lz-string": "bin/bin.js"
+            }
+        },
+        "node_modules/magic-string": {
+            "version": "0.30.11",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.11.tgz",
+            "integrity": "sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.0"
             }
         },
         "node_modules/make-dir": {
@@ -9774,6 +9953,21 @@
                 "node": ">=8"
             }
         },
+        "node_modules/pathe": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+            "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+            "dev": true
+        },
+        "node_modules/pathval": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+            "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+            "dev": true,
+            "engines": {
+                "node": ">= 14.16"
+            }
+        },
         "node_modules/pg": {
             "version": "8.12.0",
             "resolved": "https://registry.npmjs.org/pg/-/pg-8.12.0.tgz",
@@ -10318,6 +10512,17 @@
                 "react-hook-form": "^7.52.0",
                 "react-router": "^6.22.0",
                 "react-router-dom": "^6.22.0"
+            }
+        },
+        "node_modules/ra-data-fakerest": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/ra-data-fakerest/-/ra-data-fakerest-5.1.1.tgz",
+            "integrity": "sha512-NdbhvddvAuN/P3mmF13Cb/rX1pRaF4O+wHpaeNuOGzs0x8fGh4DjpkTiRnLbsX0+gLn+dPWHnPsePQFW71K7uQ==",
+            "dependencies": {
+                "fakerest": "^4.0.1"
+            },
+            "peerDependencies": {
+                "ra-core": "^5.0.0"
             }
         },
         "node_modules/ra-i18n-polyglot": {
@@ -11237,6 +11442,12 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true
+        },
         "node_modules/signal-exit": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -11355,6 +11566,18 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true
+        },
+        "node_modules/std-env": {
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.7.0.tgz",
+            "integrity": "sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==",
+            "dev": true
         },
         "node_modules/stop-iteration-iterator": {
             "version": "1.0.0",
@@ -11754,6 +11977,39 @@
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
             "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
+        },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true
+        },
+        "node_modules/tinypool": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.0.tgz",
+            "integrity": "sha512-KIKExllK7jp3uvrNtvRBYBWBOAXSX8ZvoaD8T+7KB/QHIuoJW3Pmr60zucywjAlMb5TeXUkcs/MWeWLu0qvuAQ==",
+            "dev": true,
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            }
+        },
+        "node_modules/tinyrainbow": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+            "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/tinyspy": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.0.tgz",
+            "integrity": "sha512-q5nmENpTHgiPVd1cJDDc9cVoYN5x4vCvwT3FMilvKPKneCBZAxn2YWQjDF0UMcE9k0Cay1gBiDfTMU0g+mPMQA==",
+            "dev": true,
+            "engines": {
+                "node": ">=14.0.0"
+            }
         },
         "node_modules/tmp": {
             "version": "0.0.33",
@@ -12168,6 +12424,187 @@
                 }
             }
         },
+        "node_modules/vite-node": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.0.5.tgz",
+            "integrity": "sha512-LdsW4pxj0Ot69FAoXZ1yTnA9bjGohr2yNBU7QKRxpz8ITSkhuDl6h3zS/tvgz4qrNjeRnvrWeXQ8ZF7Um4W00Q==",
+            "dev": true,
+            "dependencies": {
+                "cac": "^6.7.14",
+                "debug": "^4.3.5",
+                "pathe": "^1.1.2",
+                "tinyrainbow": "^1.2.0",
+                "vite": "^5.0.0"
+            },
+            "bin": {
+                "vite-node": "vite-node.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/vitest": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.0.5.tgz",
+            "integrity": "sha512-8GUxONfauuIdeSl5f9GTgVEpg5BTOlplET4WEDaeY2QBiN8wSm68vxN/tb5z405OwppfoCavnwXafiaYBC/xOA==",
+            "dev": true,
+            "dependencies": {
+                "@ampproject/remapping": "^2.3.0",
+                "@vitest/expect": "2.0.5",
+                "@vitest/pretty-format": "^2.0.5",
+                "@vitest/runner": "2.0.5",
+                "@vitest/snapshot": "2.0.5",
+                "@vitest/spy": "2.0.5",
+                "@vitest/utils": "2.0.5",
+                "chai": "^5.1.1",
+                "debug": "^4.3.5",
+                "execa": "^8.0.1",
+                "magic-string": "^0.30.10",
+                "pathe": "^1.1.2",
+                "std-env": "^3.7.0",
+                "tinybench": "^2.8.0",
+                "tinypool": "^1.0.0",
+                "tinyrainbow": "^1.2.0",
+                "vite": "^5.0.0",
+                "vite-node": "2.0.5",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@types/node": "^18.0.0 || >=20.0.0",
+                "@vitest/browser": "2.0.5",
+                "@vitest/ui": "2.0.5",
+                "happy-dom": "*",
+                "jsdom": "*"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vitest/node_modules/execa": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+            "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+            "dev": true,
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^8.0.1",
+                "human-signals": "^5.0.0",
+                "is-stream": "^3.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^5.1.0",
+                "onetime": "^6.0.0",
+                "signal-exit": "^4.1.0",
+                "strip-final-newline": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=16.17"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/vitest/node_modules/get-stream": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+            "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+            "dev": true,
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/vitest/node_modules/human-signals": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+            "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=16.17.0"
+            }
+        },
+        "node_modules/vitest/node_modules/is-stream": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+            "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+            "dev": true,
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/vitest/node_modules/mimic-fn": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+            "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/vitest/node_modules/onetime": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+            "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+            "dev": true,
+            "dependencies": {
+                "mimic-fn": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/vitest/node_modules/strip-final-newline": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+            "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/warning": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
@@ -12296,6 +12733,22 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/widest-line": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "lodash": "~4.17.5",
         "papaparse": "^5.4.1",
         "prop-types": "^15.8.1",
+        "ra-data-fakerest": "^5.1.1",
         "ra-supabase": "^3.0.0",
         "react": "^18.2.0",
         "react-admin": "^5.1.0",
@@ -56,9 +57,11 @@
         "supabase": "^1.136.3",
         "typescript": "^5.3.3",
         "vite": "^5.0.12",
+        "vitest": "^2.0.5",
         "web-vitals": "^4.2.2"
     },
     "scripts": {
+        "test": "vitest",
         "dev": "vite --force",
         "build": "tsc && vite build",
         "preview": "vite preview",

--- a/setupFiles/jest.ts
+++ b/setupFiles/jest.ts
@@ -1,0 +1,4 @@
+import { vi } from 'vitest';
+
+// This ensures compatibility with RA demo repository
+Object.assign(globalThis, { jest: vi });

--- a/src/providers/fakerest/authProvider.ts
+++ b/src/providers/fakerest/authProvider.ts
@@ -1,0 +1,1 @@
+export const authProvider = null;

--- a/src/providers/fakerest/dataProvider.ts
+++ b/src/providers/fakerest/dataProvider.ts
@@ -1,0 +1,1 @@
+export const dataProvider = null;

--- a/src/providers/fakerest/index.ts
+++ b/src/providers/fakerest/index.ts
@@ -1,0 +1,2 @@
+export { authProvider } from './authProvider';
+export { dataProvider } from './dataProvider';

--- a/src/providers/fakerest/internal/transformContainsFilter.spec.ts
+++ b/src/providers/fakerest/internal/transformContainsFilter.spec.ts
@@ -1,0 +1,24 @@
+// sum.test.js
+import { transformContainsFilter } from './transformContainsFilter';
+
+it('should throw an error if the filter is not a string', () => {
+    expect(() => transformContainsFilter(1)).toThrow(
+        "Invalid '@cs' filter value, expected a string matching '\\{[a-z0-9-]+(,[a-z0-9-]+)*\\}', got: 1"
+    );
+});
+
+it('should throw an error if the filter does not match pattern', () => {
+    expect(() => transformContainsFilter('1,2')).toThrow(
+        "Invalid '@cs' filter value, expected a string matching '\\{[a-z0-9-]+(,[a-z0-9-]+)*\\}', got: 1,2"
+    );
+});
+
+it('should return an array of numbers', () => {
+    expect(transformContainsFilter('{1}')).toEqual([1]);
+    expect(transformContainsFilter('{1,2,3}')).toEqual([1, 2, 3]);
+});
+
+it('should return an array of strings', () => {
+    expect(transformContainsFilter('{a}')).toEqual(['a']);
+    expect(transformContainsFilter('{a,B,c-d}')).toEqual(['a', 'B', 'c-d']);
+});

--- a/src/providers/fakerest/internal/transformContainsFilter.spec.ts
+++ b/src/providers/fakerest/internal/transformContainsFilter.spec.ts
@@ -1,16 +1,23 @@
 // sum.test.js
-import { transformContainsFilter } from './transformContainsFilter';
+import {
+    CONTAINS_FILTER_REGEX,
+    transformContainsFilter,
+} from './transformContainsFilter';
 
 it('should throw an error if the filter is not a string', () => {
     expect(() => transformContainsFilter(1)).toThrow(
-        "Invalid '@cs' filter value, expected a string matching '\\{[a-z0-9-]+(,[a-z0-9-]+)*\\}', got: 1"
+        `Invalid '@cs' filter value, expected a string matching '${CONTAINS_FILTER_REGEX.source}', got: 1`
     );
 });
 
 it('should throw an error if the filter does not match pattern', () => {
     expect(() => transformContainsFilter('1,2')).toThrow(
-        "Invalid '@cs' filter value, expected a string matching '\\{[a-z0-9-]+(,[a-z0-9-]+)*\\}', got: 1,2"
+        `Invalid '@cs' filter value, expected a string matching '${CONTAINS_FILTER_REGEX.source}', got: 1,2`
     );
+});
+
+it('should support empty arrays', () => {
+    expect(transformContainsFilter('{}')).toEqual([]);
 });
 
 it('should return an array of numbers', () => {

--- a/src/providers/fakerest/internal/transformContainsFilter.ts
+++ b/src/providers/fakerest/internal/transformContainsFilter.ts
@@ -1,9 +1,14 @@
-const CONTAINS_FILTER_REGEX = /^\{[a-z0-9-]+(,[a-z0-9-]+)*\}$/i;
+export const CONTAINS_FILTER_REGEX =
+    /^\{[A-Za-zÀ-ÖØ-öø-ÿ0-9-]+(,[A-Za-zÀ-ÖØ-öø-ÿ0-9-]+)*\}$/i;
 
 export function transformContainsFilter(value: any) {
+    if (value === '{}') {
+        return [];
+    }
+
     if (typeof value !== 'string' || !value.match(CONTAINS_FILTER_REGEX)) {
         throw new Error(
-            `Invalid '@cs' filter value, expected a string matching '\\{[a-z0-9-]+(,[a-z0-9-]+)*\\}', got: ${value}`
+            `Invalid '@cs' filter value, expected a string matching '${CONTAINS_FILTER_REGEX.source}', got: ${value}`
         );
     }
 

--- a/src/providers/fakerest/internal/transformContainsFilter.ts
+++ b/src/providers/fakerest/internal/transformContainsFilter.ts
@@ -1,9 +1,9 @@
-const IN_FILTER_REGEX = /^\([a-z0-9-]+(,[a-z0-9-]+)*\)$/i;
+const CONTAINS_FILTER_REGEX = /^\{[a-z0-9-]+(,[a-z0-9-]+)*\}$/i;
 
-export function transformInFilter(value: any) {
-    if (typeof value !== 'string' || !value.match(IN_FILTER_REGEX)) {
+export function transformContainsFilter(value: any) {
+    if (typeof value !== 'string' || !value.match(CONTAINS_FILTER_REGEX)) {
         throw new Error(
-            `Invalid '@in' filter value, expected a string matching '\\([a-z0-9-]+(,[a-z0-9-]+)*\\)', got: ${value}`
+            `Invalid '@cs' filter value, expected a string matching '\\{[a-z0-9-]+(,[a-z0-9-]+)*\\}', got: ${value}`
         );
     }
 

--- a/src/providers/fakerest/internal/transformFilter.ts
+++ b/src/providers/fakerest/internal/transformFilter.ts
@@ -1,5 +1,6 @@
 import { transformContainsFilter } from './transformContainsFilter';
 import { transformInFilter } from './transformInFilter';
+import { transformOrFilter } from './transformOrFilter';
 
 export function transformFilter(filter: Record<string, any>) {
     const transformedFilters: Record<string, any> = {};
@@ -28,6 +29,12 @@ export function transformFilter(filter: Record<string, any>) {
         if (key.endsWith('@cs')) {
             transformedFilters[`${key.slice(0, -3)}`] =
                 transformContainsFilter(value);
+            continue;
+        }
+
+        // Search query
+        if (key.endsWith('@or')) {
+            transformedFilters['q'] = transformOrFilter(value);
             continue;
         }
 

--- a/src/providers/fakerest/internal/transformFilter.ts
+++ b/src/providers/fakerest/internal/transformFilter.ts
@@ -1,0 +1,37 @@
+import { transformContainsFilter } from './transformContainsFilter';
+import { transformInFilter } from './transformInFilter';
+
+export function transformFilter(filter: Record<string, any>) {
+    const transformedFilters: Record<string, any> = {};
+    for (const [key, value] of Object.entries(filter)) {
+        if (
+            key.endsWith('@eq') ||
+            key.endsWith('@neq') ||
+            key.endsWith('@lt') ||
+            key.endsWith('@lte') ||
+            key.endsWith('@gt') ||
+            key.endsWith('@gte')
+        ) {
+            const lastIndexOfAt = key.lastIndexOf('@');
+            transformedFilters[
+                `${key.substring(0, lastIndexOfAt)}_${key.substring(lastIndexOfAt + 1)}`
+            ] = value;
+            continue;
+        }
+
+        if (key.endsWith('@in')) {
+            transformedFilters[`${key.slice(0, -3)}_eq_any`] =
+                transformInFilter(value);
+            continue;
+        }
+
+        if (key.endsWith('@cs')) {
+            transformedFilters[`${key.slice(0, -3)}`] =
+                transformContainsFilter(value);
+            continue;
+        }
+
+        transformedFilters[key] = value;
+    }
+    return transformedFilters;
+}

--- a/src/providers/fakerest/internal/transformFilter.ts
+++ b/src/providers/fakerest/internal/transformFilter.ts
@@ -20,6 +20,16 @@ export function transformFilter(filter: Record<string, any>) {
             continue;
         }
 
+        if (key.endsWith('@is')) {
+            transformedFilters[`${key.slice(0, -3)}_eq`] = value;
+            continue;
+        }
+
+        if (key.endsWith('@not.is')) {
+            transformedFilters[`${key.slice(0, -7)}_neq`] = value;
+            continue;
+        }
+
         if (key.endsWith('@in')) {
             transformedFilters[`${key.slice(0, -3)}_eq_any`] =
                 transformInFilter(value);

--- a/src/providers/fakerest/internal/transformInFilter.spec.ts
+++ b/src/providers/fakerest/internal/transformInFilter.spec.ts
@@ -1,0 +1,24 @@
+// sum.test.js
+import { transformInFilter } from './transformInFilter';
+
+it('should throw an error if the filter is not a string', () => {
+    expect(() => transformInFilter(1)).toThrow(
+        "Invalid '@in' filter value, expected a string matching '(\\d+(,\\d)*)', got: 1"
+    );
+});
+
+it('should throw an error if the filter does not match pattern', () => {
+    expect(() => transformInFilter('1,2')).toThrow(
+        "Invalid '@in' filter value, expected a string matching '(\\d+(,\\d)*)', got: 1,2"
+    );
+});
+
+it('should return an array of numbers', () => {
+    expect(transformInFilter('(1)')).toEqual([1]);
+    expect(transformInFilter('(1,2,3)')).toEqual([1, 2, 3]);
+});
+
+it('should return an array of strings', () => {
+    expect(transformInFilter('(a)')).toEqual(['a']);
+    expect(transformInFilter('(a,B,c-d)')).toEqual(['a', 'B', 'c-d']);
+});

--- a/src/providers/fakerest/internal/transformInFilter.spec.ts
+++ b/src/providers/fakerest/internal/transformInFilter.spec.ts
@@ -3,13 +3,13 @@ import { transformInFilter } from './transformInFilter';
 
 it('should throw an error if the filter is not a string', () => {
     expect(() => transformInFilter(1)).toThrow(
-        "Invalid '@in' filter value, expected a string matching '(\\d+(,\\d)*)', got: 1"
+        "Invalid '@in' filter value, expected a string matching '\\([a-z0-9-]+(,[a-z0-9-]+)*\\)', got: 1"
     );
 });
 
 it('should throw an error if the filter does not match pattern', () => {
     expect(() => transformInFilter('1,2')).toThrow(
-        "Invalid '@in' filter value, expected a string matching '(\\d+(,\\d)*)', got: 1,2"
+        "Invalid '@in' filter value, expected a string matching '\\([a-z0-9-]+(,[a-z0-9-]+)*\\)', got: 1,2"
     );
 });
 

--- a/src/providers/fakerest/internal/transformInFilter.spec.ts
+++ b/src/providers/fakerest/internal/transformInFilter.spec.ts
@@ -1,16 +1,20 @@
 // sum.test.js
-import { transformInFilter } from './transformInFilter';
+import { IN_FILTER_REGEX, transformInFilter } from './transformInFilter';
 
 it('should throw an error if the filter is not a string', () => {
     expect(() => transformInFilter(1)).toThrow(
-        "Invalid '@in' filter value, expected a string matching '\\([a-z0-9-]+(,[a-z0-9-]+)*\\)', got: 1"
+        `Invalid '@in' filter value, expected a string matching '${IN_FILTER_REGEX.source}', got: 1`
     );
 });
 
 it('should throw an error if the filter does not match pattern', () => {
     expect(() => transformInFilter('1,2')).toThrow(
-        "Invalid '@in' filter value, expected a string matching '\\([a-z0-9-]+(,[a-z0-9-]+)*\\)', got: 1,2"
+        `Invalid '@in' filter value, expected a string matching '${IN_FILTER_REGEX.source}', got: 1,2`
     );
+});
+
+it('should support empty arrays', () => {
+    expect(transformInFilter('()')).toEqual([]);
 });
 
 it('should return an array of numbers', () => {

--- a/src/providers/fakerest/internal/transformInFilter.ts
+++ b/src/providers/fakerest/internal/transformInFilter.ts
@@ -1,0 +1,20 @@
+const IN_FILTER_REGEX = /^\([a-z0-9-]+(,[a-z0-9-]+)*\)$/i;
+
+export function transformInFilter(value: any) {
+    if (typeof value !== 'string' || !value.match(IN_FILTER_REGEX)) {
+        throw new Error(
+            `Invalid '@in' filter value, expected a string matching '(\\d+(,\\d)*)', got: ${value}`
+        );
+    }
+
+    return value
+        .slice(1, -1)
+        .split(',')
+        .map((v: string) => {
+            const parsedFloat = Number.parseFloat(v);
+            if (!Number.isNaN(parsedFloat)) {
+                return parsedFloat;
+            }
+            return v;
+        });
+}

--- a/src/providers/fakerest/internal/transformInFilter.ts
+++ b/src/providers/fakerest/internal/transformInFilter.ts
@@ -1,9 +1,14 @@
-const IN_FILTER_REGEX = /^\([a-z0-9-]+(,[a-z0-9-]+)*\)$/i;
+export const IN_FILTER_REGEX =
+    /^\([A-Za-zÀ-ÖØ-öø-ÿ0-9-]+(,[A-Za-zÀ-ÖØ-öø-ÿ0-9-]+)*\)$/i;
 
 export function transformInFilter(value: any) {
+    if (value === '()') {
+        return [];
+    }
+
     if (typeof value !== 'string' || !value.match(IN_FILTER_REGEX)) {
         throw new Error(
-            `Invalid '@in' filter value, expected a string matching '\\([a-z0-9-]+(,[a-z0-9-]+)*\\)', got: ${value}`
+            `Invalid '@in' filter value, expected a string matching '${IN_FILTER_REGEX.source}', got: ${value}`
         );
     }
 

--- a/src/providers/fakerest/internal/transformOrFilter.spec.ts
+++ b/src/providers/fakerest/internal/transformOrFilter.spec.ts
@@ -1,0 +1,24 @@
+// sum.test.js
+import { transformOrFilter } from './transformOrFilter';
+
+it('should throw an error if the value is not an object', () => {
+    expect(() => transformOrFilter([])).toThrow(
+        "Invalid '@or' filter, expected an object"
+    );
+});
+
+it('should throw an error if the object is empty', () => {
+    expect(() => transformOrFilter({})).toThrow(
+        "Invalid '@or' filter, object is empty"
+    );
+});
+
+it('should return the query value', () => {
+    expect(transformOrFilter({ 'last_name@ilike': 'one' })).toEqual('one');
+    expect(
+        transformOrFilter({
+            'last_name@ilike': 'one',
+            'first_name@ilike': 'one',
+        })
+    ).toEqual('one');
+});

--- a/src/providers/fakerest/internal/transformOrFilter.ts
+++ b/src/providers/fakerest/internal/transformOrFilter.ts
@@ -1,0 +1,17 @@
+import { isObject } from 'lodash';
+
+// @or filter is an equivaluent of fakerest `q=`
+export function transformOrFilter(values: any) {
+    if (!isObject(values) || Array.isArray(values)) {
+        throw new Error(
+            "Invalid '@or' filter, expected an object as first element"
+        );
+    }
+
+    const queries = Object.values(values);
+    if (queries.length === 0) {
+        throw new Error("Invalid '@or' filter, object is empty");
+    }
+
+    return queries[0];
+}

--- a/src/providers/fakerest/supabaseAdapter.spec.ts
+++ b/src/providers/fakerest/supabaseAdapter.spec.ts
@@ -162,6 +162,28 @@ describe('getList', () => {
         });
     });
 
+    it("should transform '@or'", () => {
+        const getList = jest.fn();
+        const mockDataProvider = {
+            getList,
+        } as unknown as DataProvider;
+
+        getList.mockResolvedValueOnce([{ id: 1 }]);
+
+        const { getList: getListAdapter } =
+            withSupabaseFilterAdapter(mockDataProvider);
+
+        expect(
+            getListAdapter('resource', {
+                filter: { '@or': { last_name: 'one' } },
+            })
+        ).resolves.toEqual([{ id: 1 }]);
+
+        expect(getList).toHaveBeenCalledWith('resource', {
+            filter: { q: 'one' },
+        });
+    });
+
     it('should not transform a filter without operator', () => {
         const getList = jest.fn();
         const mockDataProvider = {
@@ -421,6 +443,36 @@ describe('getManyReference', () => {
             pagination: { page: 1, perPage: 10 },
             sort: { field: 'id', order: 'ASC' },
             filter: { tags: [1, 2, 'a'] },
+        });
+    });
+
+    it("should transform '@or'", () => {
+        const getManyReference = jest.fn();
+        const mockDataProvider = {
+            getManyReference,
+        } as unknown as DataProvider;
+
+        getManyReference.mockResolvedValueOnce([{ id: 1 }]);
+
+        const { getManyReference: getManyReferenceAdapter } =
+            withSupabaseFilterAdapter(mockDataProvider);
+
+        expect(
+            getManyReferenceAdapter('resource', {
+                id: 1,
+                target: 'target',
+                pagination: { page: 1, perPage: 10 },
+                sort: { field: 'id', order: 'ASC' },
+                filter: { '@or': { last_name: 'one' } },
+            })
+        ).resolves.toEqual([{ id: 1 }]);
+
+        expect(getManyReference).toHaveBeenCalledWith('resource', {
+            id: 1,
+            target: 'target',
+            pagination: { page: 1, perPage: 10 },
+            sort: { field: 'id', order: 'ASC' },
+            filter: { q: 'one' },
         });
     });
 

--- a/src/providers/fakerest/supabaseAdapter.spec.ts
+++ b/src/providers/fakerest/supabaseAdapter.spec.ts
@@ -42,6 +42,86 @@ describe('getList', () => {
         });
     });
 
+    it("should transform '@eq'", () => {
+        const getList = jest.fn();
+        const mockDataProvider = {
+            getList,
+        } as unknown as DataProvider;
+
+        getList.mockResolvedValueOnce([{ id: 1 }]);
+
+        const { getList: getListAdapter } =
+            withSupabaseFilterAdapter(mockDataProvider);
+
+        expect(
+            getListAdapter('resource', { filter: { 'a@id@eq': '1' } })
+        ).resolves.toEqual([{ id: 1 }]);
+
+        expect(getList).toHaveBeenCalledWith('resource', {
+            filter: { 'a@id_eq': '1' },
+        });
+    });
+
+    it("should transform '@neq'", () => {
+        const getList = jest.fn();
+        const mockDataProvider = {
+            getList,
+        } as unknown as DataProvider;
+
+        getList.mockResolvedValueOnce([{ id: 1 }]);
+
+        const { getList: getListAdapter } =
+            withSupabaseFilterAdapter(mockDataProvider);
+
+        expect(
+            getListAdapter('resource', { filter: { 'a@id@neq': '1' } })
+        ).resolves.toEqual([{ id: 1 }]);
+
+        expect(getList).toHaveBeenCalledWith('resource', {
+            filter: { 'a@id_neq': '1' },
+        });
+    });
+
+    it("should transform '@is'", () => {
+        const getList = jest.fn();
+        const mockDataProvider = {
+            getList,
+        } as unknown as DataProvider;
+
+        getList.mockResolvedValueOnce([{ id: 1 }]);
+
+        const { getList: getListAdapter } =
+            withSupabaseFilterAdapter(mockDataProvider);
+
+        expect(
+            getListAdapter('resource', { filter: { 'id@is': null } })
+        ).resolves.toEqual([{ id: 1 }]);
+
+        expect(getList).toHaveBeenCalledWith('resource', {
+            filter: { id_eq: null },
+        });
+    });
+
+    it("should transform '@not.is'", () => {
+        const getList = jest.fn();
+        const mockDataProvider = {
+            getList,
+        } as unknown as DataProvider;
+
+        getList.mockResolvedValueOnce([{ id: 1 }]);
+
+        const { getList: getListAdapter } =
+            withSupabaseFilterAdapter(mockDataProvider);
+
+        expect(
+            getListAdapter('resource', { filter: { 'id@not.is': null } })
+        ).resolves.toEqual([{ id: 1 }]);
+
+        expect(getList).toHaveBeenCalledWith('resource', {
+            filter: { id_neq: null },
+        });
+    });
+
     it("should transform '@lt'", () => {
         const getList = jest.fn();
         const mockDataProvider = {
@@ -263,6 +343,66 @@ describe('getManyReference', () => {
             pagination: { page: 1, perPage: 10 },
             sort: { field: 'id', order: 'ASC' },
             filter: { 'a@id_neq': '2' },
+        });
+    });
+
+    it('should transform @is', () => {
+        const getManyReference = jest.fn();
+        const mockDataProvider = {
+            getManyReference,
+        } as unknown as DataProvider;
+
+        getManyReference.mockResolvedValueOnce([{ id: 1 }]);
+
+        const { getManyReference: getManyReferenceAdapter } =
+            withSupabaseFilterAdapter(mockDataProvider);
+
+        expect(
+            getManyReferenceAdapter('resource', {
+                id: 1,
+                target: 'target',
+                pagination: { page: 1, perPage: 10 },
+                sort: { field: 'id', order: 'ASC' },
+                filter: { 'id@is': null },
+            })
+        ).resolves.toEqual([{ id: 1 }]);
+
+        expect(getManyReference).toHaveBeenCalledWith('resource', {
+            id: 1,
+            target: 'target',
+            pagination: { page: 1, perPage: 10 },
+            sort: { field: 'id', order: 'ASC' },
+            filter: { id_eq: null },
+        });
+    });
+
+    it('should transform @not.is', () => {
+        const getManyReference = jest.fn();
+        const mockDataProvider = {
+            getManyReference,
+        } as unknown as DataProvider;
+
+        getManyReference.mockResolvedValueOnce([{ id: 1 }]);
+
+        const { getManyReference: getManyReferenceAdapter } =
+            withSupabaseFilterAdapter(mockDataProvider);
+
+        expect(
+            getManyReferenceAdapter('resource', {
+                id: 1,
+                target: 'target',
+                pagination: { page: 1, perPage: 10 },
+                sort: { field: 'id', order: 'ASC' },
+                filter: { 'id@not.is': null },
+            })
+        ).resolves.toEqual([{ id: 1 }]);
+
+        expect(getManyReference).toHaveBeenCalledWith('resource', {
+            id: 1,
+            target: 'target',
+            pagination: { page: 1, perPage: 10 },
+            sort: { field: 'id', order: 'ASC' },
+            filter: { id_neq: null },
         });
     });
 

--- a/src/providers/fakerest/supabaseAdapter.spec.ts
+++ b/src/providers/fakerest/supabaseAdapter.spec.ts
@@ -1,0 +1,106 @@
+import { DataProvider } from 'react-admin';
+import { withSupabaseFilterAdapter } from './supabaseAdapter';
+
+describe('getList', () => {
+    it("should transform '@in'", () => {
+        const getList = jest.fn();
+        const mockDataProvider = {
+            getList,
+        } as unknown as DataProvider;
+
+        getList.mockResolvedValueOnce([{ id: 1 }]);
+
+        const { getList: getListAdapter } =
+            withSupabaseFilterAdapter(mockDataProvider);
+
+        expect(
+            getListAdapter('resource', { filter: { 'id@in': '(1,2,a)' } })
+        ).resolves.toEqual([{ id: 1 }]);
+
+        expect(getList).toHaveBeenCalledWith('resource', {
+            filter: { id_eq_any: [1, 2, 'a'] },
+        });
+    });
+
+    it('should not transform a filter without operator', () => {
+        const getList = jest.fn();
+        const mockDataProvider = {
+            getList,
+        } as unknown as DataProvider;
+
+        getList.mockResolvedValueOnce([{ id: 1 }]);
+
+        const { getList: getListAdapter } =
+            withSupabaseFilterAdapter(mockDataProvider);
+
+        expect(
+            getListAdapter('resource', { filter: { id: 1 } })
+        ).resolves.toEqual([{ id: 1 }]);
+
+        expect(getList).toHaveBeenCalledWith('resource', {
+            filter: { id: 1 },
+        });
+    });
+});
+
+describe('getManyReference', () => {
+    it("should transform '@in'", () => {
+        const getManyReference = jest.fn();
+        const mockDataProvider = {
+            getManyReference,
+        } as unknown as DataProvider;
+
+        getManyReference.mockResolvedValueOnce([{ id: 1 }]);
+
+        const { getManyReference: getManyReferenceAdapter } =
+            withSupabaseFilterAdapter(mockDataProvider);
+
+        expect(
+            getManyReferenceAdapter('resource', {
+                id: 1,
+                target: 'target',
+                pagination: { page: 1, perPage: 10 },
+                sort: { field: 'id', order: 'ASC' },
+                filter: { 'id@in': '(1,2,a)' },
+            })
+        ).resolves.toEqual([{ id: 1 }]);
+
+        expect(getManyReference).toHaveBeenCalledWith('resource', {
+            id: 1,
+            target: 'target',
+            pagination: { page: 1, perPage: 10 },
+            sort: { field: 'id', order: 'ASC' },
+            filter: { id_eq_any: [1, 2, 'a'] },
+        });
+    });
+
+    it('should not transform a filter without operator', () => {
+        const getManyReference = jest.fn();
+        const mockDataProvider = {
+            getManyReference,
+        } as unknown as DataProvider;
+
+        getManyReference.mockResolvedValueOnce([{ id: 1 }]);
+
+        const { getManyReference: getManyReferenceAdapter } =
+            withSupabaseFilterAdapter(mockDataProvider);
+
+        expect(
+            getManyReferenceAdapter('resource', {
+                id: 1,
+                target: 'target',
+                pagination: { page: 1, perPage: 10 },
+                sort: { field: 'id', order: 'ASC' },
+                filter: { id: 2 },
+            })
+        ).resolves.toEqual([{ id: 1 }]);
+
+        expect(getManyReference).toHaveBeenCalledWith('resource', {
+            id: 1,
+            target: 'target',
+            pagination: { page: 1, perPage: 10 },
+            sort: { field: 'id', order: 'ASC' },
+            filter: { id: 2 },
+        });
+    });
+});

--- a/src/providers/fakerest/supabaseAdapter.spec.ts
+++ b/src/providers/fakerest/supabaseAdapter.spec.ts
@@ -2,6 +2,126 @@ import { DataProvider } from 'react-admin';
 import { withSupabaseFilterAdapter } from './supabaseAdapter';
 
 describe('getList', () => {
+    it("should transform '@eq'", () => {
+        const getList = jest.fn();
+        const mockDataProvider = {
+            getList,
+        } as unknown as DataProvider;
+
+        getList.mockResolvedValueOnce([{ id: 1 }]);
+
+        const { getList: getListAdapter } =
+            withSupabaseFilterAdapter(mockDataProvider);
+
+        expect(
+            getListAdapter('resource', { filter: { 'a@id@eq': '1' } })
+        ).resolves.toEqual([{ id: 1 }]);
+
+        expect(getList).toHaveBeenCalledWith('resource', {
+            filter: { 'a@id_eq': '1' },
+        });
+    });
+
+    it("should transform '@neq'", () => {
+        const getList = jest.fn();
+        const mockDataProvider = {
+            getList,
+        } as unknown as DataProvider;
+
+        getList.mockResolvedValueOnce([{ id: 1 }]);
+
+        const { getList: getListAdapter } =
+            withSupabaseFilterAdapter(mockDataProvider);
+
+        expect(
+            getListAdapter('resource', { filter: { 'a@id@neq': '1' } })
+        ).resolves.toEqual([{ id: 1 }]);
+
+        expect(getList).toHaveBeenCalledWith('resource', {
+            filter: { 'a@id_neq': '1' },
+        });
+    });
+
+    it("should transform '@lt'", () => {
+        const getList = jest.fn();
+        const mockDataProvider = {
+            getList,
+        } as unknown as DataProvider;
+
+        getList.mockResolvedValueOnce([{ id: 1 }]);
+
+        const { getList: getListAdapter } =
+            withSupabaseFilterAdapter(mockDataProvider);
+
+        expect(
+            getListAdapter('resource', { filter: { 'a@id@lt': '1' } })
+        ).resolves.toEqual([{ id: 1 }]);
+
+        expect(getList).toHaveBeenCalledWith('resource', {
+            filter: { 'a@id_lt': '1' },
+        });
+    });
+
+    it("should transform '@lte'", () => {
+        const getList = jest.fn();
+        const mockDataProvider = {
+            getList,
+        } as unknown as DataProvider;
+
+        getList.mockResolvedValueOnce([{ id: 1 }]);
+
+        const { getList: getListAdapter } =
+            withSupabaseFilterAdapter(mockDataProvider);
+
+        expect(
+            getListAdapter('resource', { filter: { 'a@id@lte': '1' } })
+        ).resolves.toEqual([{ id: 1 }]);
+
+        expect(getList).toHaveBeenCalledWith('resource', {
+            filter: { 'a@id_lte': '1' },
+        });
+    });
+
+    it("should transform '@gt'", () => {
+        const getList = jest.fn();
+        const mockDataProvider = {
+            getList,
+        } as unknown as DataProvider;
+
+        getList.mockResolvedValueOnce([{ id: 1 }]);
+
+        const { getList: getListAdapter } =
+            withSupabaseFilterAdapter(mockDataProvider);
+
+        expect(
+            getListAdapter('resource', { filter: { 'a@id@gt': '1' } })
+        ).resolves.toEqual([{ id: 1 }]);
+
+        expect(getList).toHaveBeenCalledWith('resource', {
+            filter: { 'a@id_gt': '1' },
+        });
+    });
+
+    it("should transform '@gte'", () => {
+        const getList = jest.fn();
+        const mockDataProvider = {
+            getList,
+        } as unknown as DataProvider;
+
+        getList.mockResolvedValueOnce([{ id: 1 }]);
+
+        const { getList: getListAdapter } =
+            withSupabaseFilterAdapter(mockDataProvider);
+
+        expect(
+            getListAdapter('resource', { filter: { 'a@id@gte': '1' } })
+        ).resolves.toEqual([{ id: 1 }]);
+
+        expect(getList).toHaveBeenCalledWith('resource', {
+            filter: { 'a@id_gte': '1' },
+        });
+    });
+
     it("should transform '@in'", () => {
         const getList = jest.fn();
         const mockDataProvider = {
@@ -64,6 +184,186 @@ describe('getList', () => {
 });
 
 describe('getManyReference', () => {
+    it('should transform @eq', () => {
+        const getManyReference = jest.fn();
+        const mockDataProvider = {
+            getManyReference,
+        } as unknown as DataProvider;
+
+        getManyReference.mockResolvedValueOnce([{ id: 1 }]);
+
+        const { getManyReference: getManyReferenceAdapter } =
+            withSupabaseFilterAdapter(mockDataProvider);
+
+        expect(
+            getManyReferenceAdapter('resource', {
+                id: 1,
+                target: 'target',
+                pagination: { page: 1, perPage: 10 },
+                sort: { field: 'id', order: 'ASC' },
+                filter: { 'a@id@eq': '2' },
+            })
+        ).resolves.toEqual([{ id: 1 }]);
+
+        expect(getManyReference).toHaveBeenCalledWith('resource', {
+            id: 1,
+            target: 'target',
+            pagination: { page: 1, perPage: 10 },
+            sort: { field: 'id', order: 'ASC' },
+            filter: { 'a@id_eq': '2' },
+        });
+    });
+
+    it('should transform @neq', () => {
+        const getManyReference = jest.fn();
+        const mockDataProvider = {
+            getManyReference,
+        } as unknown as DataProvider;
+
+        getManyReference.mockResolvedValueOnce([{ id: 1 }]);
+
+        const { getManyReference: getManyReferenceAdapter } =
+            withSupabaseFilterAdapter(mockDataProvider);
+
+        expect(
+            getManyReferenceAdapter('resource', {
+                id: 1,
+                target: 'target',
+                pagination: { page: 1, perPage: 10 },
+                sort: { field: 'id', order: 'ASC' },
+                filter: { 'a@id@neq': '2' },
+            })
+        ).resolves.toEqual([{ id: 1 }]);
+
+        expect(getManyReference).toHaveBeenCalledWith('resource', {
+            id: 1,
+            target: 'target',
+            pagination: { page: 1, perPage: 10 },
+            sort: { field: 'id', order: 'ASC' },
+            filter: { 'a@id_neq': '2' },
+        });
+    });
+
+    it('should transform @lt', () => {
+        const getManyReference = jest.fn();
+        const mockDataProvider = {
+            getManyReference,
+        } as unknown as DataProvider;
+
+        getManyReference.mockResolvedValueOnce([{ id: 1 }]);
+
+        const { getManyReference: getManyReferenceAdapter } =
+            withSupabaseFilterAdapter(mockDataProvider);
+
+        expect(
+            getManyReferenceAdapter('resource', {
+                id: 1,
+                target: 'target',
+                pagination: { page: 1, perPage: 10 },
+                sort: { field: 'id', order: 'ASC' },
+                filter: { 'a@id@lt': '2' },
+            })
+        ).resolves.toEqual([{ id: 1 }]);
+
+        expect(getManyReference).toHaveBeenCalledWith('resource', {
+            id: 1,
+            target: 'target',
+            pagination: { page: 1, perPage: 10 },
+            sort: { field: 'id', order: 'ASC' },
+            filter: { 'a@id_lt': '2' },
+        });
+    });
+
+    it('should transform @lte', () => {
+        const getManyReference = jest.fn();
+        const mockDataProvider = {
+            getManyReference,
+        } as unknown as DataProvider;
+
+        getManyReference.mockResolvedValueOnce([{ id: 1 }]);
+
+        const { getManyReference: getManyReferenceAdapter } =
+            withSupabaseFilterAdapter(mockDataProvider);
+
+        expect(
+            getManyReferenceAdapter('resource', {
+                id: 1,
+                target: 'target',
+                pagination: { page: 1, perPage: 10 },
+                sort: { field: 'id', order: 'ASC' },
+                filter: { 'a@id@lte': '2' },
+            })
+        ).resolves.toEqual([{ id: 1 }]);
+
+        expect(getManyReference).toHaveBeenCalledWith('resource', {
+            id: 1,
+            target: 'target',
+            pagination: { page: 1, perPage: 10 },
+            sort: { field: 'id', order: 'ASC' },
+            filter: { 'a@id_lte': '2' },
+        });
+    });
+
+    it('should transform @gt', () => {
+        const getManyReference = jest.fn();
+        const mockDataProvider = {
+            getManyReference,
+        } as unknown as DataProvider;
+
+        getManyReference.mockResolvedValueOnce([{ id: 1 }]);
+
+        const { getManyReference: getManyReferenceAdapter } =
+            withSupabaseFilterAdapter(mockDataProvider);
+
+        expect(
+            getManyReferenceAdapter('resource', {
+                id: 1,
+                target: 'target',
+                pagination: { page: 1, perPage: 10 },
+                sort: { field: 'id', order: 'ASC' },
+                filter: { 'a@id@gt': '2' },
+            })
+        ).resolves.toEqual([{ id: 1 }]);
+
+        expect(getManyReference).toHaveBeenCalledWith('resource', {
+            id: 1,
+            target: 'target',
+            pagination: { page: 1, perPage: 10 },
+            sort: { field: 'id', order: 'ASC' },
+            filter: { 'a@id_gt': '2' },
+        });
+    });
+
+    it('should transform @gte', () => {
+        const getManyReference = jest.fn();
+        const mockDataProvider = {
+            getManyReference,
+        } as unknown as DataProvider;
+
+        getManyReference.mockResolvedValueOnce([{ id: 1 }]);
+
+        const { getManyReference: getManyReferenceAdapter } =
+            withSupabaseFilterAdapter(mockDataProvider);
+
+        expect(
+            getManyReferenceAdapter('resource', {
+                id: 1,
+                target: 'target',
+                pagination: { page: 1, perPage: 10 },
+                sort: { field: 'id', order: 'ASC' },
+                filter: { 'a@id@gte': '2' },
+            })
+        ).resolves.toEqual([{ id: 1 }]);
+
+        expect(getManyReference).toHaveBeenCalledWith('resource', {
+            id: 1,
+            target: 'target',
+            pagination: { page: 1, perPage: 10 },
+            sort: { field: 'id', order: 'ASC' },
+            filter: { 'a@id_gte': '2' },
+        });
+    });
+
     it("should transform '@in'", () => {
         const getManyReference = jest.fn();
         const mockDataProvider = {

--- a/src/providers/fakerest/supabaseAdapter.spec.ts
+++ b/src/providers/fakerest/supabaseAdapter.spec.ts
@@ -22,6 +22,26 @@ describe('getList', () => {
         });
     });
 
+    it("should transform '@cs'", () => {
+        const getList = jest.fn();
+        const mockDataProvider = {
+            getList,
+        } as unknown as DataProvider;
+
+        getList.mockResolvedValueOnce([{ id: 1 }]);
+
+        const { getList: getListAdapter } =
+            withSupabaseFilterAdapter(mockDataProvider);
+
+        expect(
+            getListAdapter('resource', { filter: { 'tags@cs': '{1,2,a}' } })
+        ).resolves.toEqual([{ id: 1 }]);
+
+        expect(getList).toHaveBeenCalledWith('resource', {
+            filter: { tags: [1, 2, 'a'] },
+        });
+    });
+
     it('should not transform a filter without operator', () => {
         const getList = jest.fn();
         const mockDataProvider = {
@@ -71,6 +91,36 @@ describe('getManyReference', () => {
             pagination: { page: 1, perPage: 10 },
             sort: { field: 'id', order: 'ASC' },
             filter: { id_eq_any: [1, 2, 'a'] },
+        });
+    });
+
+    it("should transform '@cs'", () => {
+        const getManyReference = jest.fn();
+        const mockDataProvider = {
+            getManyReference,
+        } as unknown as DataProvider;
+
+        getManyReference.mockResolvedValueOnce([{ id: 1 }]);
+
+        const { getManyReference: getManyReferenceAdapter } =
+            withSupabaseFilterAdapter(mockDataProvider);
+
+        expect(
+            getManyReferenceAdapter('resource', {
+                id: 1,
+                target: 'target',
+                pagination: { page: 1, perPage: 10 },
+                sort: { field: 'id', order: 'ASC' },
+                filter: { 'tags@cs': '{1,2,a}' },
+            })
+        ).resolves.toEqual([{ id: 1 }]);
+
+        expect(getManyReference).toHaveBeenCalledWith('resource', {
+            id: 1,
+            target: 'target',
+            pagination: { page: 1, perPage: 10 },
+            sort: { field: 'id', order: 'ASC' },
+            filter: { tags: [1, 2, 'a'] },
         });
     });
 

--- a/src/providers/fakerest/supabaseAdapter.ts
+++ b/src/providers/fakerest/supabaseAdapter.ts
@@ -1,4 +1,5 @@
 import { DataProvider } from 'react-admin';
+import { transformContainsFilter } from './internal/transformContainsFilter';
 import { transformInFilter } from './internal/transformInFilter';
 
 function transformFilter(filter: Record<string, any>) {
@@ -7,6 +8,12 @@ function transformFilter(filter: Record<string, any>) {
         if (key.endsWith('@in')) {
             transformedFilters[`${key.slice(0, -3)}_eq_any`] =
                 transformInFilter(value);
+            continue;
+        }
+
+        if (key.endsWith('@cs')) {
+            transformedFilters[`${key.slice(0, -3)}`] =
+                transformContainsFilter(value);
             continue;
         }
 

--- a/src/providers/fakerest/supabaseAdapter.ts
+++ b/src/providers/fakerest/supabaseAdapter.ts
@@ -1,26 +1,5 @@
 import { DataProvider } from 'react-admin';
-import { transformContainsFilter } from './internal/transformContainsFilter';
-import { transformInFilter } from './internal/transformInFilter';
-
-function transformFilter(filter: Record<string, any>) {
-    const transformedFilters: Record<string, any> = {};
-    for (const [key, value] of Object.entries(filter)) {
-        if (key.endsWith('@in')) {
-            transformedFilters[`${key.slice(0, -3)}_eq_any`] =
-                transformInFilter(value);
-            continue;
-        }
-
-        if (key.endsWith('@cs')) {
-            transformedFilters[`${key.slice(0, -3)}`] =
-                transformContainsFilter(value);
-            continue;
-        }
-
-        transformedFilters[key] = value;
-    }
-    return transformedFilters;
-}
+import { transformFilter } from './internal/transformFilter';
 
 export function withSupabaseFilterAdapter<T extends DataProvider>(
     dataProvider: T

--- a/src/providers/fakerest/supabaseAdapter.ts
+++ b/src/providers/fakerest/supabaseAdapter.ts
@@ -1,0 +1,36 @@
+import { DataProvider } from 'react-admin';
+import { transformInFilter } from './internal/transformInFilter';
+
+function transformFilter(filter: Record<string, any>) {
+    const transformedFilters: Record<string, any> = {};
+    for (const [key, value] of Object.entries(filter)) {
+        if (key.endsWith('@in')) {
+            transformedFilters[`${key.slice(0, -3)}_eq_any`] =
+                transformInFilter(value);
+            continue;
+        }
+
+        transformedFilters[key] = value;
+    }
+    return transformedFilters;
+}
+
+export function withSupabaseFilterAdapter<T extends DataProvider>(
+    dataProvider: T
+): T {
+    return {
+        ...dataProvider,
+        getList(resource, params) {
+            return dataProvider.getList(resource, {
+                ...params,
+                filter: transformFilter(params.filter),
+            });
+        },
+        getManyReference(resource, params) {
+            return dataProvider.getManyReference(resource, {
+                ...params,
+                filter: transformFilter(params.filter),
+            });
+        },
+    };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
         "resolveJsonModule": true,
         "isolatedModules": true,
         "noEmit": true,
-        "jsx": "react-jsx"
+        "jsx": "react-jsx",
+        "types": ["vitest/globals"]
     },
     "include": ["src"],
     "references": [{ "path": "./tsconfig.node.json" }]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        setupFiles: ['./setupFiles/jest.ts'],
+        globals: true,
+    },
+});


### PR DESCRIPTION
## Problem

We want to support both supabase and fake rest as auth and data providers. However, supabase list filters are not compatible with fake rest's ones.

Filters to support:
- [x] eq
- [x] neq
- [X] in
- [x] cs
- [x] is
- [x] not.is
- [x] lt
- [x] lte
- [x] gt
- [x] gte
- [x] or
- [x] ilike
- [x] like

## Solution

Add an adapter from supabase filters to fake rest filters.

## How To Test

Replace `dataProvider` and `authProvider` by fake rest one's in `root/CRM.tsx`

## Additional Checks

- [X] The **documentation** is up to date
