### PR TITLE
Fix(ops): GitHub pages were not pushed as expected

### DIFF
--- a/scripts/ghpages-deploy.mjs
+++ b/scripts/ghpages-deploy.mjs
@@ -1,7 +1,17 @@
 import * as ghpages from 'gh-pages';
 
-ghpages.publish('dist', { branch: 'gh-pages' }, function (err) {
-    if (err) {
-        console.error('Failed to deploy to GitHub Pages', err);
+ghpages.publish(
+    'dist',
+    {
+        branch: 'gh-pages',
+        user: {
+            name: process.env.GIT_USER_NAME || 'Marmebot',
+            email: process.env.GIT_USER_EMAIL || 'developer@marmelab.com',
+        },
+    },
+    function (err) {
+        if (err) {
+            console.error('Failed to deploy to GitHub Pages', err);
+        }
     }
-});
+);


### PR DESCRIPTION
## Problem

The static pages were not deployed automatically as git user was not defined

## Solution

Force a user in gh pages script

## Additional Checks

- [X] The **documentation** is up to date
