### PR TITLE
Fix(views): Add security invokers to views to avoid data leak

### DIFF
--- a/supabase/migrations/20240730075029_init_db.sql
+++ b/supabase/migrations/20240730075029_init_db.sql
@@ -563,7 +563,9 @@ CREATE POLICY "Attachments 1mt4rzk_3" ON storage.objects FOR DELETE TO authentic
 
 -- Use Postgres to create views for companies.
 
-create view "public"."companies_summary" as
+create view "public"."companies_summary"
+    with (security_invoker=on)
+    as
 select 
     c.*,
     count(distinct d.id) as nb_deals,
@@ -579,7 +581,9 @@ group by
     
 -- Use Postgres to create views for contacts.
 
-create view "public"."contacts_summary" as
+create view "public"."contacts_summary"
+    with (security_invoker=on)
+    as
 select 
     co.*,
     c.name as company_name,

--- a/supabase/migrations/20240730075425_init_triggers.sql
+++ b/supabase/migrations/20240730075425_init_triggers.sql
@@ -49,7 +49,9 @@ create trigger on_auth_user_updated
   after update on auth.users
   for each row execute procedure public.handle_update_user();
 
-create view init_state as
+create view init_state
+  with (security_invoker=off)
+  as
 select count(id) as is_initialized
 from public.sales
 limit 1;


### PR DESCRIPTION
## Problem

Views are public by default and could leak data

## Solution

Add security to views except `init_state` as it MUST be public and is designed to be secure

## How To Test

You must reset DB, add contacts and access to `http://127.0.0.1:54321/rest/v1/contacts_summary`. You should get and empty array

## Additional Checks

- [X] The **documentation** is up to date
