### PR TITLE
Fix(migrations): recreate contact_summary view in remove acquisition migration

### DIFF
--- a/supabase/migrations/20240807082449_remove-aquisition.sql
+++ b/supabase/migrations/20240807082449_remove-aquisition.sql
@@ -1,2 +1,20 @@
+-- this will drop the `contacts_summary` view as well
 ALTER TABLE  "public"."contacts"
 DROP COLUMN acquisition CASCADE;
+
+ -- We need to recreate the view with the new schema
+
+create view "public"."contacts_summary"
+as
+select 
+    co.*,
+    c.name as company_name,
+    count(distinct t.id) as nb_tasks
+from
+    "public"."contacts" co
+left join
+    "public"."tasks" t on co.id = t.contact_id
+left join
+    "public"."companies" c on co.company_id = c.id
+group by
+    co.id, c.name;


### PR DESCRIPTION
## Problem

contacts_summary view was dropped in a migration

## Solution

recreate contacts_summary view in the remove acquisition migration