### PR TITLE
Feat(ops): Add option to deploy to another repository

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
             VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
             VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
             VITE_IS_DEMO: ${{ vars.VITE_IS_DEMO }}
-            DEPLOY_REPO_URL: ${{ secrets.DEPLOY_REPO_URL }}
+            DEPLOY_REPO_URL: ${{ vars.DEPLOY_REPO_URL }}
 
         steps:
             - name: 📥 Checkout repo

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
             VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
             VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
             VITE_IS_DEMO: ${{ vars.VITE_IS_DEMO }}
-
+            DEPLOY_REPO_URL: ${{ secrets.DEPLOY_REPO_URL }}
 
         steps:
             - name: 📥 Checkout repo

--- a/README.md
+++ b/README.md
@@ -91,27 +91,7 @@ You can then access the app via [`http://localhost:3000/`](http://localhost:3000
 
 ## GitHub Actions
 
-This project supports github actions for continuous integration and delivery. To enable GitHub actions on this repo, you will
-have to create the following secrets:
-
-```bash
-SUPABASE_ACCESS_TOKEN: Your personal access token, can be found at https://supabase.com/dashboard/account/tokens
-SUPABASE_DB_PASSWORD: Your supabase database password
-SUPABASE_PROJECT_ID: Your supabase project id
-SUPABASE_URL: Your supabase project URL
-SUPABASE_ANON_KEY: Your supabase project anonymous key
-```
-
-Also, you will need to configure the some variables:
-```bash
-VITE_IS_DEMO: Set to `true` if you want to display the demo banner
-```
-
-You will also need to configure the following environment variables to deploy to GH pages:
-```bash
-GIT_USER_NAME: The deploy account's name
-GIT_USER_EMAIL: The deploy user's email
-```
+Learn how to [configure GitHub Actions for Atomic CRM](./doc/github-actions.md).
 
 ## Customizing
 

--- a/doc/github-actions.md
+++ b/doc/github-actions.md
@@ -2,7 +2,7 @@
 
 ## Configuration
 
-his project supports github actions for continuous integration and delivery. To enable GitHub actions on this repo, you will
+This project supports github actions for continuous integration and delivery. To enable GitHub actions on this repo, you will
 have to create the following secrets:
 
 ```bash
@@ -11,11 +11,6 @@ SUPABASE_DB_PASSWORD: Your supabase database password
 SUPABASE_PROJECT_ID: Your supabase project id
 SUPABASE_URL: Your supabase project URL
 SUPABASE_ANON_KEY: Your supabase project anonymous key
-```
-
-Also, you will need to configure the some variables:
-```bash
-VITE_IS_DEMO: Set to `true` if you want to display the demo banner
 ```
 
 ## Deploying to Another Repository

--- a/doc/github-actions.md
+++ b/doc/github-actions.md
@@ -1,0 +1,26 @@
+# GitHub Actions
+
+## Configuration
+
+his project supports github actions for continuous integration and delivery. To enable GitHub actions on this repo, you will
+have to create the following secrets:
+
+```bash
+SUPABASE_ACCESS_TOKEN: Your personal access token, can be found at https://supabase.com/dashboard/account/tokens
+SUPABASE_DB_PASSWORD: Your supabase database password
+SUPABASE_PROJECT_ID: Your supabase project id
+SUPABASE_URL: Your supabase project URL
+SUPABASE_ANON_KEY: Your supabase project anonymous key
+```
+
+Also, you will need to configure the some variables:
+```bash
+VITE_IS_DEMO: Set to `true` if you want to display the demo banner
+```
+
+## Deploying to Another Repository
+
+If you want to deploy the static website to another repository, you can configure the following secret on you repository:
+```bash
+DEPLOY_REPO_URL=git@github.com:<org>/<repository>.git
+```

--- a/doc/github-actions.md
+++ b/doc/github-actions.md
@@ -15,7 +15,7 @@ SUPABASE_ANON_KEY: Your supabase project anonymous key
 
 ## Deploying to Another Repository
 
-If you want to deploy the static website to another repository, you can configure the following secret on you repository:
+If you want to deploy the static website to another repository, you can configure the following variable on you repository:
 ```bash
 DEPLOY_REPO_URL=git@github.com:<org>/<repository>.git
 ```

--- a/scripts/ghpages-deploy.mjs
+++ b/scripts/ghpages-deploy.mjs
@@ -4,6 +4,7 @@ ghpages.publish(
     'dist',
     {
         branch: 'gh-pages',
+        repo: process.env.DEPLOY_REPO_URL || undefined,
     },
     function (err) {
         if (err) {


### PR DESCRIPTION
## Problem

We want to deploy Atomic CRM static site to another repository

## Solution

Add a support for a GitHub action secret to configure the target repository.

## Additional Checks

- [X] The **documentation** is up to date
