### PR TITLE
fix(crm): Fix signup page logo color

### DIFF
--- a/src/login/SignupPage.tsx
+++ b/src/login/SignupPage.tsx
@@ -72,7 +72,12 @@ export const SignupPage = () => {
     return (
         <Stack sx={{ height: '100dvh', p: 2 }}>
             <Stack direction="row" alignItems="center" gap={1}>
-                <img src={logo} alt={title} width={50} />
+                <img
+                    src={logo}
+                    alt={title}
+                    width={50}
+                    style={{ filter: 'invert(0.9)' }}
+                />
                 <Typography component="span" variant="h5">
                     {title}
                 </Typography>


### PR DESCRIPTION
## Problem

On the signup page, the logo is almost invisible (white on a white background).

![image](https://github.com/user-attachments/assets/73186d2b-6a82-4274-bd68-330bacb8d823)


## Solution

Invert the logo color on the signup page

![2024-08-08_15-21](https://github.com/user-attachments/assets/231f03bc-2d98-478b-9052-9760fddaa36a)


## How To Test

Clear your database and run `make start`

