### PR TITLE
Fix(perf): Logout user if db has been reset and improve login page load performance

### DIFF
--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -1,5 +1,5 @@
-import SettingsIcon from '@mui/icons-material/Settings';
 import PeopleIcon from '@mui/icons-material/People';
+import SettingsIcon from '@mui/icons-material/Settings';
 import {
     AppBar,
     Box,

--- a/src/login/SignupPage.tsx
+++ b/src/login/SignupPage.tsx
@@ -7,7 +7,12 @@ import {
     Typography,
 } from '@mui/material';
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { useDataProvider, useLogin, useNotify } from 'react-admin';
+import {
+    useDataProvider,
+    useLogin,
+    useNotify,
+    usePermissions,
+} from 'react-admin';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { Navigate } from 'react-router';
 import { CrmDataProvider } from '../providers/types';
@@ -16,6 +21,7 @@ import { SignUpData } from '../types';
 import { LoginSkeleton } from './LoginSkeleton';
 
 export const SignupPage = () => {
+    const { refetch } = usePermissions();
     const dataProvider = useDataProvider<CrmDataProvider>();
     const { logo, title } = useConfigurationContext();
     const { data: isInitialized, isPending } = useQuery({
@@ -35,10 +41,10 @@ export const SignupPage = () => {
                 email: data.email,
                 password: data.password,
                 redirectTo: '/contacts',
-            });
-            setTimeout(() => {
+            }).then(() => {
                 notify('Initial user successfully created');
-            }, 0);
+                refetch();
+            });
         },
         onError: () => {
             notify('An error occurred. Please try again.');

--- a/src/providers/supabase/authProvider.ts
+++ b/src/providers/supabase/authProvider.ts
@@ -58,6 +58,7 @@ export const authProvider: AuthProvider = {
         const isInitialized = await getIsInitialized();
 
         if (!isInitialized) {
+            await supabase.auth.signOut();
             // eslint-disable-next-line no-throw-literal
             throw {
                 redirectTo: '/sign-up',

--- a/src/root/CRM.tsx
+++ b/src/root/CRM.tsx
@@ -159,26 +159,18 @@ export const CRM = ({
                     element={<ForgotPasswordPage />}
                 />
             </CustomRoutes>
-            {permissions => (
-                <>
-                    <CustomRoutes>
-                        <Route
-                            path={SettingsPage.path}
-                            element={<SettingsPage />}
-                        />
-                    </CustomRoutes>
-                    <Resource name="deals" {...deals} />
-                    <Resource name="contacts" {...contacts} />
-                    <Resource name="companies" {...companies} />
-                    <Resource name="contactNotes" />
-                    <Resource name="dealNotes" />
-                    <Resource name="tasks" list={ListGuesser} />
-                    {permissions === 'admin' ? (
-                        <Resource name="sales" {...sales} />
-                    ) : null}
-                    <Resource name="tags" list={ListGuesser} />
-                </>
-            )}
+
+            <CustomRoutes>
+                <Route path={SettingsPage.path} element={<SettingsPage />} />
+            </CustomRoutes>
+            <Resource name="deals" {...deals} />
+            <Resource name="contacts" {...contacts} />
+            <Resource name="companies" {...companies} />
+            <Resource name="contactNotes" />
+            <Resource name="dealNotes" />
+            <Resource name="tasks" list={ListGuesser} />
+            <Resource name="sales" {...sales} />
+            <Resource name="tags" list={ListGuesser} />
         </Admin>
     </ConfigurationProvider>
 );

--- a/src/sales/SalesCreate.tsx
+++ b/src/sales/SalesCreate.tsx
@@ -6,14 +6,17 @@ import {
     SimpleForm,
     useDataProvider,
     useNotify,
+    usePermissions,
     useRedirect,
 } from 'react-admin';
 import { SubmitHandler } from 'react-hook-form';
+import { Navigate } from 'react-router';
 import { CrmDataProvider } from '../providers/types';
 import { SalesFormData } from '../types';
 import { SalesInputs } from './SalesInputs';
 
 export function SalesCreate() {
+    const { isPending, permissions } = usePermissions();
     const dataProvider = useDataProvider<CrmDataProvider>();
     const notify = useNotify();
     const redirect = useRedirect();
@@ -33,6 +36,14 @@ export function SalesCreate() {
     const onSubmit: SubmitHandler<SalesFormData> = async data => {
         mutate(data);
     };
+
+    if (isPending) {
+        return null;
+    }
+
+    if (permissions !== 'admin') {
+        return <Navigate to="/" />;
+    }
 
     return (
         <Container maxWidth="sm" sx={{ mt: 4 }}>

--- a/src/sales/SalesEdit.tsx
+++ b/src/sales/SalesEdit.tsx
@@ -7,10 +7,12 @@ import {
     useDataProvider,
     useEditController,
     useNotify,
+    usePermissions,
     useRecordContext,
     useRedirect,
 } from 'react-admin';
 import { SubmitHandler } from 'react-hook-form';
+import { Navigate } from 'react-router';
 import { CrmDataProvider } from '../providers/types';
 import { Sale, SalesFormData } from '../types';
 import { SalesInputs } from './SalesInputs';
@@ -24,6 +26,8 @@ function EditToolbar() {
 }
 
 export function SalesEdit() {
+    const { isPending, permissions } = usePermissions();
+
     const { record } = useEditController();
 
     const dataProvider = useDataProvider<CrmDataProvider>();
@@ -49,6 +53,14 @@ export function SalesEdit() {
     const onSubmit: SubmitHandler<SalesFormData> = async data => {
         mutate(data);
     };
+
+    if (isPending) {
+        return null;
+    }
+
+    if (permissions !== 'admin') {
+        return <Navigate to="/" />;
+    }
 
     return (
         <Container maxWidth="sm" sx={{ mt: 4 }}>

--- a/src/sales/SalesList.tsx
+++ b/src/sales/SalesList.tsx
@@ -8,7 +8,9 @@ import {
     SearchInput,
     TextField,
     TopToolbar,
+    usePermissions,
 } from 'react-admin';
+import { Navigate } from 'react-router';
 
 function SalesListActions() {
     return (
@@ -22,6 +24,15 @@ function SalesListActions() {
 const filters = [<SearchInput source="q" alwaysOn />];
 
 export function SalesList() {
+    const { isPending, permissions } = usePermissions();
+    if (isPending) {
+        return null;
+    }
+
+    if (permissions !== 'admin') {
+        return <Navigate to="/" />;
+    }
+
     return (
         <Stack gap={4}>
             <List


### PR DESCRIPTION
## Problems

- First user cannot create sale on first login
- Login page is slow to load

## Solution

- Move permission check to slaes pages
- Refetch permissions on signup

## How To Test

Cleanup your db while your are still connected and create a new account

## Additional Checks

- [X] The **documentation** is up to date
- [ ] ~~Tested with **fakerest** provider (see [related documentation](../doc/data-providers.md))~~ *N/A*
