### PR TITLE
Sec(init_state): init_state view is no longer leaking sales count

### DIFF
--- a/supabase/migrations/20240808141826_init_state_configure.sql
+++ b/supabase/migrations/20240808141826_init_state_configure.sql
@@ -1,0 +1,9 @@
+create or replace view init_state
+  with (security_invoker=off)
+  as
+select count(id) as is_initialized
+from (
+  select id 
+  from public.sales
+  limit 1
+) as sub;


### PR DESCRIPTION
## Problem

Init state view was leaking sales count

## Solution

Use subquery to avoid data leak

## How To Test

Create multiple sales and access to `init_state` 

## Additional Checks

- [X] The **documentation** is up to date
- [ ] ~~Tested with **fakerest** provider (see [related documentation](../doc/data-providers.md))~~ *(N∕A)*
