### PR TITLE
Fix(avatar): Avatar upload does not fail anymore if no change in file…

### DIFF
--- a/src/misc/ImageEditorField.tsx
+++ b/src/misc/ImageEditorField.tsx
@@ -97,12 +97,14 @@ const ImageEditorDialog = (props: ImageEditorDialogProps) => {
         const croppedImage = cropper?.getCroppedCanvas().toDataURL();
         if (croppedImage) {
             setImageSrc(croppedImage);
+
+            const newFile = file ?? new File([], initialValue?.src);
             setValue(
                 props.source,
                 {
                     src: croppedImage,
-                    title: file?.name,
-                    rawFile: file,
+                    title: newFile.name,
+                    rawFile: newFile,
                 },
                 { shouldDirty: true }
             );

--- a/src/providers/supabase/dataProvider.ts
+++ b/src/providers/supabase/dataProvider.ts
@@ -359,13 +359,17 @@ const uploadToBucket = async (fi: RAFile) => {
         }
     }
 
+    const dataContent = fi.src
+        ? await fetch(fi.src).then(res => res.blob())
+        : fi.rawFile;
+
     const file = fi.rawFile;
     const fileExt = file.name.split('.').pop();
     const fileName = `${Math.random()}.${fileExt}`;
     const filePath = `${fileName}`;
     const { error: uploadError } = await supabase.storage
         .from('attachments')
-        .upload(filePath, file);
+        .upload(filePath, dataContent);
 
     if (uploadError) {
         console.error('uploadError', uploadError);


### PR DESCRIPTION
… hasbeen done

## Problem

It was not possible to save an avatar if the file had not changed

## Solution

Mock raw file if not in form

## How To Test

1. Go to User Menu / My info
2. Click on “change” link close to avatar
3. Upload an image
4. resize/span
5. Save
6. REFRESH THE PAGE
7. Click on Change the avatar again
8. resize/span
9. Save
10. 

## Additional Checks

- [X] The **documentation** is up to date
- [ ] ~~Tested with **fakerest** provider (see [related documentation](../doc/data-providers.md))~~ *(N/A)*
