### PR TITLE
fix(login): Fix user is not automatically logged in after signup

### DIFF
--- a/src/providers/supabase/authProvider.ts
+++ b/src/providers/supabase/authProvider.ts
@@ -55,6 +55,28 @@ export namespace getIsInitialized {
 export const authProvider: AuthProvider = {
     ...baseAuthProvider,
     checkAuth: async params => {
+        // Users are on the set-password page, nothing to do
+        if (
+            window.location.pathname === '/set-password' ||
+            window.location.hash.includes('#/set-password')
+        ) {
+            return;
+        }
+        // Users are on the forgot-password page, nothing to do
+        if (
+            window.location.pathname === '/forgot-password' ||
+            window.location.hash.includes('#/forgot-password')
+        ) {
+            return;
+        }
+        // Users are on the sign-up page, nothing to do
+        if (
+            window.location.pathname === '/sign-up' ||
+            window.location.hash.includes('#/sign-up')
+        ) {
+            return;
+        }
+
         const isInitialized = await getIsInitialized();
 
         if (!isInitialized) {


### PR DESCRIPTION
## Problem

After sign up, the user is not automatically logged in.

the user has to log in after sign up for the first user

the same happens after I reset my password: I am not automatically logged in.

## Solution

Apply the same `checkAuth` implementation as in [`ra-supabase`](https://github.com/marmelab/ra-supabase/pull/67/files#diff-2f66cc28128c0000e6210759afdbf8eb6cb7597375968d7ab4e3709e2c34cad1), and also extend the mechanism to the signup page.

## How To Test

1st issue: reset the db, create the 1st user, make sure you are automatically signed in.

2nd issue: use the forgot-password feature to reset your password. After choosing a new password, make sure you are automatically signed in.

