### PR TITLE
fix(mail): Support recipient with empty Name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "papaparse": "^5.4.1",
                 "prop-types": "^15.8.1",
                 "ra-data-fakerest": "^5.1.1",
-                "ra-supabase": "^3.0.1",
+                "ra-supabase": "^3.1.0",
                 "react": "^18.2.0",
                 "react-admin": "^5.1.0",
                 "react-cropper": "^2.3.3",

--- a/src/tests/supabase/functions/postmark.spec.ts
+++ b/src/tests/supabase/functions/postmark.spec.ts
@@ -72,4 +72,81 @@ describe('extractMailContactData', () => {
             domain: 'marmelab.com',
         });
     });
+
+    it('should support multiple @ in email', () => {
+        // Because it is allowed by https://www.rfc-editor.org/rfc/rfc5322
+        const result = extractMailContactData([
+            {
+                Email: '"john@doe"@marmelab.com',
+                Name: 'John Doe',
+            },
+        ]);
+        expect(result).toEqual({
+            firstName: 'John',
+            lastName: 'Doe',
+            email: '"john@doe"@marmelab.com',
+            domain: 'marmelab.com',
+        });
+    });
+
+    it('should use first part of email when Name is empty', () => {
+        const result = extractMailContactData([
+            {
+                Email: 'john.doe@marmelab.com',
+                Name: '',
+            },
+        ]);
+        expect(result).toEqual({
+            firstName: 'john',
+            lastName: 'doe',
+            email: 'john.doe@marmelab.com',
+            domain: 'marmelab.com',
+        });
+    });
+
+    it('should use first part of email when Name is empty and support single word', () => {
+        const result = extractMailContactData([
+            {
+                Email: 'john@marmelab.com',
+                Name: '',
+            },
+        ]);
+        expect(result).toEqual({
+            firstName: '',
+            lastName: 'john',
+            email: 'john@marmelab.com',
+            domain: 'marmelab.com',
+        });
+    });
+
+    it('should use first part of email when Name is empty and support multiple words', () => {
+        const result = extractMailContactData([
+            {
+                Email: 'john.doe.multi@marmelab.com',
+                Name: '',
+            },
+        ]);
+        expect(result).toEqual({
+            firstName: 'john',
+            lastName: 'doe multi',
+            email: 'john.doe.multi@marmelab.com',
+            domain: 'marmelab.com',
+        });
+    });
+
+    it('should support empty Name and multiple @ in email', () => {
+        // Because it is allowed by https://www.rfc-editor.org/rfc/rfc5322
+        const result = extractMailContactData([
+            {
+                Email: '"john@doe"@marmelab.com',
+                Name: '',
+            },
+        ]);
+        expect(result).toEqual({
+            firstName: '"john',
+            lastName: 'doe"',
+            email: '"john@doe"@marmelab.com',
+            domain: 'marmelab.com',
+        });
+    });
 });

--- a/supabase/functions/postmark/extractMailContactData.ts
+++ b/supabase/functions/postmark/extractMailContactData.ts
@@ -28,7 +28,9 @@ export const extractMailContactData = (
     const contact = ToFull[0];
 
     const domain = contact.Email.split('@').at(-1);
-    const fullName = contact.Name;
+    const fullName =
+        contact.Name ||
+        contact.Email.split('@').slice(0, -1).join(' ').split('.').join(' ');
     let firstName = '';
     let lastName = fullName;
     if (fullName && fullName.includes(' ')) {


### PR DESCRIPTION
## Problem

When sending an email to an address that has no first and last name, it creates a contact with no first and last name.

## Solution

We should use the part of the email before the @ and split it between dots to fill the first and last name.

## How To Test

Send a message to an email not in your contacts.

Alternatively, this can be tested locally using the sample `curl` command [here](https://github.com/marmelab/atomic-crm/blob/1ddf5389db4c5c76d778a1cf8f9d3c3e58d50564/supabase/functions/postmark/index.ts#L118-L206) and clearing the `To.Name` field.

