### PR TITLE
Fix(import): tags and companies are no loger duplicated during imports

### DIFF
--- a/src/contacts/useContactImport.tsx
+++ b/src/contacts/useContactImport.tsx
@@ -49,8 +49,10 @@ export function useContactImport() {
 
             const entities = uncachedEntities.length
                 ? await dataProvider.getList(entity, {
-                      filter: { name: uncachedEntities },
-                      pagination: { page: 1, perPage: 1 },
+                      filter: {
+                          'name@in': `(${uncachedEntities.map(entity => `"${entity}"`).join(',')})`,
+                      },
+                      pagination: { page: 1, perPage: trimmedNames.length },
                       sort: { field: 'id', order: 'ASC' },
                   })
                 : { data: [] };

--- a/src/providers/fakerest/internal/listParser.ts
+++ b/src/providers/fakerest/internal/listParser.ts
@@ -1,0 +1,48 @@
+export const UNQUOTED_ALLOWED_CHARS = '[A-Za-zÀ-ÖØ-öø-ÿ0-9-]+';
+export const QUOTED_ALLOWED_CHARS = '[A-Za-zÀ-ÖØ-öø-ÿ0-9, -]+';
+export const LIST_REGEX_BASE = `(${UNQUOTED_ALLOWED_CHARS}|"${QUOTED_ALLOWED_CHARS}")(,(${UNQUOTED_ALLOWED_CHARS}|"${QUOTED_ALLOWED_CHARS}"))*`;
+
+/**
+ * List represents a list of values, quoted or not.
+ *
+ * e.g. 1
+ * e.g 1,2
+ * e.g "a","b"
+ * e.g "a",b
+ */
+export function parseList(list: string) {
+    const parsedItems = [];
+
+    let currentItem = '';
+    let currentQuoted = false;
+    for (const char of list) {
+        if (char === ',') {
+            if (currentQuoted) {
+                currentItem += char;
+                continue;
+            }
+
+            parsedItems.push(currentItem);
+            currentItem = '';
+            continue;
+        }
+
+        if (char === '"') {
+            currentQuoted = !currentQuoted;
+            continue;
+        }
+
+        currentItem += char;
+    }
+    if (currentItem) {
+        parsedItems.push(currentItem);
+    }
+
+    return parsedItems.map((v: string) => {
+        const parsedFloat = Number.parseFloat(v);
+        if (!Number.isNaN(parsedFloat)) {
+            return parsedFloat;
+        }
+        return v;
+    });
+}

--- a/src/providers/fakerest/internal/transformContainsFilter.spec.ts
+++ b/src/providers/fakerest/internal/transformContainsFilter.spec.ts
@@ -29,3 +29,8 @@ it('should return an array of strings', () => {
     expect(transformContainsFilter('{a}')).toEqual(['a']);
     expect(transformContainsFilter('{a,B,c-d}')).toEqual(['a', 'B', 'c-d']);
 });
+
+it('should return an array of quoted strings', () => {
+    expect(transformContainsFilter('{"a"}')).toEqual(['a']);
+    expect(transformContainsFilter('{"a","B, c"}')).toEqual(['a', 'B, c']);
+});

--- a/src/providers/fakerest/internal/transformContainsFilter.ts
+++ b/src/providers/fakerest/internal/transformContainsFilter.ts
@@ -1,5 +1,6 @@
-export const CONTAINS_FILTER_REGEX =
-    /^\{[A-Za-zÀ-ÖØ-öø-ÿ0-9-]+(,[A-Za-zÀ-ÖØ-öø-ÿ0-9-]+)*\}$/i;
+import { LIST_REGEX_BASE, parseList } from './listParser';
+
+export const CONTAINS_FILTER_REGEX = new RegExp(`^\\{${LIST_REGEX_BASE}\\}$`);
 
 export function transformContainsFilter(value: any) {
     if (value === '{}') {
@@ -12,14 +13,5 @@ export function transformContainsFilter(value: any) {
         );
     }
 
-    return value
-        .slice(1, -1)
-        .split(',')
-        .map((v: string) => {
-            const parsedFloat = Number.parseFloat(v);
-            if (!Number.isNaN(parsedFloat)) {
-                return parsedFloat;
-            }
-            return v;
-        });
+    return parseList(value.slice(1, -1));
 }

--- a/src/providers/fakerest/internal/transformInFilter.spec.ts
+++ b/src/providers/fakerest/internal/transformInFilter.spec.ts
@@ -26,3 +26,8 @@ it('should return an array of strings', () => {
     expect(transformInFilter('(a)')).toEqual(['a']);
     expect(transformInFilter('(a,B,c-d)')).toEqual(['a', 'B', 'c-d']);
 });
+
+it('should return an array of quoted strings', () => {
+    expect(transformInFilter('("a")')).toEqual(['a']);
+    expect(transformInFilter('("a","B, c")')).toEqual(['a', 'B, c']);
+});

--- a/src/providers/fakerest/internal/transformInFilter.ts
+++ b/src/providers/fakerest/internal/transformInFilter.ts
@@ -1,5 +1,6 @@
-export const IN_FILTER_REGEX =
-    /^\([A-Za-zÀ-ÖØ-öø-ÿ0-9-]+(,[A-Za-zÀ-ÖØ-öø-ÿ0-9-]+)*\)$/i;
+import { LIST_REGEX_BASE, parseList } from './listParser';
+
+export const IN_FILTER_REGEX = new RegExp(`^\\(${LIST_REGEX_BASE}\\)$`);
 
 export function transformInFilter(value: any) {
     if (value === '()') {
@@ -12,14 +13,5 @@ export function transformInFilter(value: any) {
         );
     }
 
-    return value
-        .slice(1, -1)
-        .split(',')
-        .map((v: string) => {
-            const parsedFloat = Number.parseFloat(v);
-            if (!Number.isNaN(parsedFloat)) {
-                return parsedFloat;
-            }
-            return v;
-        });
+    return parseList(value.slice(1, -1));
 }


### PR DESCRIPTION
## Problem

During imports, companies and tags are duplicated

## Solution

Use an '@in' operator instead of an array in `useContactImport`

## How To Test

1. Go to the contacts page
2. Click on the import button
3. Download the sample CSV
4. Upload the sample CSV
5. Import

## Additional Checks

- [X] The **documentation** is up to date
- [X] Tested with **fakerest** provider (see [related documentation](../doc/data-providers.md))
