### PR TITLE
Fix(note): Improve note spacing

### DIFF
--- a/src/notes/Note.tsx
+++ b/src/notes/Note.tsx
@@ -170,42 +170,31 @@ export const Note = ({
                     </Box>
                 </Form>
             ) : (
-                <Box
+                <Stack
                     sx={{
                         paddingTop: '0.5em',
                         display: 'flex',
-                        alignItems: 'stretch',
+                        '& p:empty': {
+                            minHeight: '0.75em',
+                        },
                     }}
                 >
-                    <Box
-                        flex={1}
-                        sx={{
-                            '& p:first-of-type': {
-                                marginTop: 0,
-                            },
-                            '& p:last-of-type': {
-                                marginBottom: 0,
-                            },
-                        }}
-                    >
-                        {note.text
-                            ?.split('\n')
-                            .map((paragraph: string, index: number) => (
-                                <Box
-                                    component="p"
-                                    fontFamily="fontFamily"
-                                    fontSize="body2.fontSize"
-                                    lineHeight={1.5}
-                                    marginBottom={2.4}
-                                    key={index}
-                                >
-                                    {paragraph}
-                                </Box>
-                            ))}
+                    {note.text
+                        ?.split('\n')
+                        .map((paragraph: string, index: number) => (
+                            <Typography
+                                component="p"
+                                variant="body2"
+                                lineHeight={1.5}
+                                margin={0}
+                                key={index}
+                            >
+                                {paragraph}
+                            </Typography>
+                        ))}
 
-                        {note.attachments && <NoteAttachments note={note} />}
-                    </Box>
-                </Box>
+                    {note.attachments && <NoteAttachments note={note} />}
+                </Stack>
             )}
         </Box>
     );


### PR DESCRIPTION
## Problem

There is too much spacing when rendering notes

## Solution

Reduce spacing

## How To Test

[Capture vidéo du 09-08-2024 14:46:12.webm](https://github.com/user-attachments/assets/338299c6-beda-4675-b631-3b1dd1660151)

## Additional Checks

- [X] The **documentation** is up to date
- [X] Tested with **fakerest** provider (see [related documentation](../doc/data-providers.md))
