### PR TITLE
Fix(avatar): Avatar deletion is now persisted as expected

### DIFF
--- a/src/misc/ImageEditorField.tsx
+++ b/src/misc/ImageEditorField.tsx
@@ -117,7 +117,10 @@ const ImageEditorDialog = (props: ImageEditorDialogProps) => {
     };
 
     const deleteImage = () => {
-        setValue(props.source, undefined, { shouldDirty: true });
+        setValue(props.source, null, { shouldDirty: true });
+        if (props.onSave) {
+            handleSubmit(props.onSave)();
+        }
         props.onClose();
     };
 


### PR DESCRIPTION
## Problem

Avatar deletion is not persisted

## Solution

Use `null` instead of `undefined` when reseting form and submit on deletion

## How To Test

Add an avatar to profile, remove it and refresh the page

## Additional Checks

- [X] The **documentation** is up to date
- [X] Tested with **fakerest** provider (see [related documentation](../doc/data-providers.md))
