### PR TITLE
Feat(mailing): Add support for multiple recipients and fix some typos in mails

### DIFF
--- a/public/auth-callback.html
+++ b/public/auth-callback.html
@@ -131,7 +131,7 @@
         function interceptAuthCallback() {
                 const hash = window.location.hash;
                 const {access_token, refresh_token, type} = getUrlParams();
-                window.location.href = `../#/auth-callback?access_token=${access_token}&refresh_token=${refresh_token}&type=${type}`;
+                window.location.href = `./#/auth-callback?access_token=${access_token}&refresh_token=${refresh_token}&type=${type}`;
         }
     
         // Call the function to intercept the auth callback

--- a/supabase/functions/postmark/addNoteToContact.ts
+++ b/supabase/functions/postmark/addNoteToContact.ts
@@ -123,5 +123,8 @@ export const addNoteToContact = async ({
             { status: 500 }
         );
 
-    return new Response('OK');
+    await supabaseAdmin
+        .from('contacts')
+        .update({ last_seen: new Date() })
+        .eq('id', contact.id);
 };

--- a/supabase/functions/postmark/extractMailContactData.ts
+++ b/supabase/functions/postmark/extractMailContactData.ts
@@ -24,19 +24,22 @@ export const extractMailContactData = (
         Name: string;
     }[]
 ) => {
-    // We only support one recipient for now
-    const contact = ToFull[0];
-
-    const domain = contact.Email.split('@').at(-1);
-    const fullName =
-        contact.Name ||
-        contact.Email.split('@').slice(0, -1).join(' ').split('.').join(' ');
-    let firstName = '';
-    let lastName = fullName;
-    if (fullName && fullName.includes(' ')) {
-        const parts = fullName.split(' ');
-        firstName = parts[0];
-        lastName = parts.slice(1).join(' ');
-    }
-    return { firstName, lastName, email: contact.Email, domain };
+    return ToFull.map(contact => {
+        const domain = contact.Email.split('@').at(-1)!;
+        const fullName =
+            contact.Name ||
+            contact.Email.split('@')
+                .slice(0, -1)
+                .join(' ')
+                .split('.')
+                .join(' ');
+        let firstName = '';
+        let lastName = fullName;
+        if (fullName && fullName.includes(' ')) {
+            const parts = fullName.split(' ');
+            firstName = parts[0];
+            lastName = parts.slice(1).join(' ');
+        }
+        return { firstName, lastName, email: contact.Email, domain };
+    });
 };

--- a/supabase/templates/invite.html
+++ b/supabase/templates/invite.html
@@ -62,11 +62,6 @@
                     class="button"
                     >Confirm my account</a
                 >
-                <p>
-                    <strong>Warning:</strong> If the password reset request did
-                    not originate from you, please contact us immediately as
-                    this may be a fraudulent attempt.
-                </p>
                 <p>See you soon!</p>
                 <p>Atomic CRM team</p>
             </div>

--- a/supabase/templates/recovery.html
+++ b/supabase/templates/recovery.html
@@ -49,7 +49,7 @@
     <body>
         <div class="container">
             <div class="header">
-                <h2>Reset your password</h2>
+                <h2>Reset Your Atomic CRM Password</h2>
             </div>
             <div class="content">
                 <p>Hello,</p>


### PR DESCRIPTION
## Problem

- It is not supported to add multiple recipients to mails
- There is an error when resetting password
- There are typos in invite and recover mails

## Solution

- Add support 
- Fix auth redirect URL
- Improve mails wording

## How To Test

- Send a mail with inbound e-mail address in cc to multiple recepients

## Additional Checks

- [X] The **documentation** is up to date
- [ ] ~~Tested with **fakerest** provider (see [related documentation](../doc/data-providers.md))~~ *(N/A)*
