### PR TITLE
skip gh action task when needed secrets are missing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,20 +67,12 @@ jobs:
               name: 📡 Push supabase migrations
               run: npx supabase db push
 
-            - if: ${{ env.IS_SUPABASE_CONFIGURED && env.POSTMARK_WEBHOOK_USER }}
+            - if: ${{ env.IS_SUPABASE_CONFIGURED && env.POSTMARK_WEBHOOK_USER && env.POSTMARK_WEBHOOK_PASSWORD && env.POSTMARK_WEBHOOK_AUTHORIZED_IPS }}
               name: 📡 Push supabase postmark webhook user secret
               run: |
                   npx supabase secrets set POSTMARK_WEBHOOK_USER=${{ env.POSTMARK_WEBHOOK_USER }}
-
-            - if: ${{ env.IS_SUPABASE_CONFIGURED && env.POSTMARK_WEBHOOK_PASSWORD }}
-              name: 📡 Push supabase postmark webhook password secret
-              run: |
-                  npx supabase secrets set POSTMARK_WEBHOOK_PASSWORD=${{ secrets.POSTMARK_WEBHOOK_PASSWORD }}
-
-            - if: ${{ env.IS_SUPABASE_CONFIGURED && env.POSTMARK_WEBHOOK_AUTHORIZED_IPS }}
-              name: 📡 Push supabase postmark whebhook authorized IPS secret
-              run: |
-                  npx supabase secrets set POSTMARK_WEBHOOK_AUTHORIZED_IPS=${{ secrets.POSTMARK_WEBHOOK_AUTHORIZED_IPS }}
+                  npx supabase secrets set POSTMARK_WEBHOOK_PASSWORD=${{ env.POSTMARK_WEBHOOK_PASSWORD }}
+                  npx supabase secrets set POSTMARK_WEBHOOK_AUTHORIZED_IPS=${{ env.POSTMARK_WEBHOOK_AUTHORIZED_IPS }}
 
             - if: ${{ env.IS_SUPABASE_CONFIGURED }}
               name: 📡 Deploy supabase functions

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,11 +22,15 @@ jobs:
             SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
             SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
             SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
+            IS_SUPABASE_CONFIGURED: ${{ secrets.SUPABASE_ACCESS_TOKEN && secrets.SUPABASE_DB_PASSWORD && secrets.SUPABASE_PROJECT_ID }}
             VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
             VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
             VITE_IS_DEMO: ${{ vars.VITE_IS_DEMO }}
             VITE_INBOUND_EMAIL: ${{ vars.VITE_INBOUND_EMAIL }}
             PRODUCTION_REMOTE: https://git:${{ secrets.DEPLOY_TOKEN || secrets.GITHUB_TOKEN }}@github.com/${{ vars.DEPLOY_REPOSITORY || github.repository }}
+            POSTMARK_WEBHOOK_USER: ${{secrets.POSTMARK_WEBHOOK_USER}}
+            POSTMARK_WEBHOOK_PASSWORD: ${{secrets.POSTMARK_WEBHOOK_PASSWORD}}
+            POSTMARK_WEBHOOK_AUTHORIZED_IPS: ${{secrets.POSTMARK_WEBHOOK_AUTHORIZED_IPS}}
 
         steps:
             - name: 📥 Checkout repo
@@ -55,19 +59,31 @@ jobs:
             - name: 🔨 Build
               run: npm run build
             
-            - name: 🔗 Supabase Link
+            - if: ${{ env.IS_SUPABASE_CONFIGURED }}
+              name: 🔗 Supabase Link
               run: npx supabase link --project-ref $SUPABASE_PROJECT_ID
 
-            - name: 📡 Push supabase migrations
+            - if: ${{ env.IS_SUPABASE_CONFIGURED }}
+              name: 📡 Push supabase migrations
               run: npx supabase db push
 
-            - name: 📡 Push supabase functions secrets
+            - if: ${{ env.IS_SUPABASE_CONFIGURED }} && ${{ env.POSTMARK_WEBHOOK_USER }}
+              name: 📡 Push supabase postman webhook user secret
               run: |
-                  npx supabase secrets set POSTMARK_WEBHOOK_USER=${{ secrets.POSTMARK_WEBHOOK_USER }}
+                  npx supabase secrets set POSTMARK_WEBHOOK_USER=${{ env.POSTMARK_WEBHOOK_USER }}
+
+            - if: ${{ env.IS_SUPABASE_CONFIGURED }} && ${{ env.POSTMARK_WEBHOOK_PASSWORD }}
+              name: 📡 Push supabase postman webhook password secret
+              run: |
                   npx supabase secrets set POSTMARK_WEBHOOK_PASSWORD=${{ secrets.POSTMARK_WEBHOOK_PASSWORD }}
+
+            - if: ${{ env.IS_SUPABASE_CONFIGURED }} && ${{ env.POSTMARK_WEBHOOK_AUTHORIZED_IPS }}
+              name: 📡 Push supabase whebhook authorized IPS secret
+              run: |
                   npx supabase secrets set POSTMARK_WEBHOOK_AUTHORIZED_IPS=${{ secrets.POSTMARK_WEBHOOK_AUTHORIZED_IPS }}
 
-            - name: 📡 Deploy supabase functions
+            - if: ${{ env.IS_SUPABASE_CONFIGURED }}
+              name: 📡 Deploy supabase functions
               run: npx supabase functions deploy
 
             - name: 📡 Deploy GitHub pages

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,9 +22,9 @@ jobs:
             SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
             SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
             SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
-            IS_SUPABASE_CONFIGURED: ${{ secrets.SUPABASE_ACCESS_TOKEN && secrets.SUPABASE_DB_PASSWORD && secrets.SUPABASE_PROJECT_ID }}
             VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
             VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+            IS_SUPABASE_CONFIGURED: ${{ secrets.SUPABASE_ACCESS_TOKEN && secrets.SUPABASE_DB_PASSWORD && secrets.SUPABASE_PROJECT_ID && secrets.SUPABASE_URL && secrets.SUPABASE_ANON_KEY }}
             VITE_IS_DEMO: ${{ vars.VITE_IS_DEMO }}
             VITE_INBOUND_EMAIL: ${{ vars.VITE_INBOUND_EMAIL }}
             PRODUCTION_REMOTE: https://git:${{ secrets.DEPLOY_TOKEN || secrets.GITHUB_TOKEN }}@github.com/${{ vars.DEPLOY_REPOSITORY || github.repository }}
@@ -97,6 +97,14 @@ jobs:
             - if: ${{ !env.SUPABASE_PROJECT_ID }}
               name: Check SUPABASE_PROJECT_ID secret
               run: echo ':warning:SUPABASE_PROJECT_ID secret is missing' >> $GITHUB_STEP_SUMMARY
+
+            - if: ${{ !env.VITE_SUPABASE_URL }}
+              name: Check SUPABASE_URL secret
+              run: echo ':warning:SUPABASE_URL secret is missing' >> $GITHUB_STEP_SUMMARY
+
+            - if: ${{ !env.VITE_SUPABASE_ANON_KEY }}
+              name: Check SUPABASE_ANON_KEY secret
+              run: echo ':warning:SUPABASE_ANON_KEY secret is missing' >> $GITHUB_STEP_SUMMARY
 
             - if: ${{ !env.POSTMARK_WEBHOOK_USER }}
               name: Check POSTMARK_WEBHOOK_USER secret

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,6 +86,34 @@ jobs:
               name: 📡 Deploy supabase functions
               run: npx supabase functions deploy
 
+            - if: ${{ !env.SUPABASE_ACCESS_TOKEN }}
+              name: Check SUPABASE_ACCESS_TOKEN secret
+              run: echo ':warning:SUPABASE_ACCESS_TOKEN secret is missing' >> $GITHUB_STEP_SUMMARY
+
+            - if: ${{ !env.SUPABASE_DB_PASSWORD }}
+              name: Check SUPABASE_DB_PASSWORD secret
+              run: echo ':warning:SUPABASE_DB_PASSWORD secret is missing' >> $GITHUB_STEP_SUMMARY
+
+            - if: ${{ !env.SUPABASE_PROJECT_ID }}
+              name: Check SUPABASE_PROJECT_ID secret
+              run: echo ':warning:SUPABASE_PROJECT_ID secret is missing' >> $GITHUB_STEP_SUMMARY
+
+            - if: ${{ !env.POSTMARK_WEBHOOK_USER }}
+              name: Check POSTMARK_WEBHOOK_USER secret
+              run: echo ':warning:POSTMARK_WEBHOOK_USER secret is missing' >> $GITHUB_STEP_SUMMARY
+
+            - if: ${{ !env.POSTMARK_WEBHOOK_PASSWORD }}
+              name: Check POSTMARK_WEBHOOK_USER secret
+              run: echo ':warning:POSTMARK_WEBHOOK_PASSWORD secret is missing' >> $GITHUB_STEP_SUMMARY
+
+            - if: ${{ !env.POSTMARK_WEBHOOK_AUTHORIZED_IPS }}
+              name: Check POSTMARK_WEBHOOK_USER secret
+              run: echo ':warning:POSTMARK_WEBHOOK_AUTHORIZED_IPS secret is missing' >> $GITHUB_STEP_SUMMARY
+
+            - if: ${{ !env.IS_SUPABASE_CONFIGURED }}
+              name: Supabase deployment skipped
+              run: echo ':warning:Supabase deployment skipped' >> $GITHUB_STEP_SUMMARY
+
             - name: 📡 Deploy GitHub pages
               run: npx gh-pages --remote production -d dist -b ${{ vars.DEPLOY_BRANCH || 'gh-pages' }}
               env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,18 +67,18 @@ jobs:
               name: 📡 Push supabase migrations
               run: npx supabase db push
 
-            - if: ${{ env.IS_SUPABASE_CONFIGURED }} && ${{ env.POSTMARK_WEBHOOK_USER }}
-              name: 📡 Push supabase postman webhook user secret
+            - if: ${{ env.IS_SUPABASE_CONFIGURED && env.POSTMARK_WEBHOOK_USER }}
+              name: 📡 Push supabase postmark webhook user secret
               run: |
                   npx supabase secrets set POSTMARK_WEBHOOK_USER=${{ env.POSTMARK_WEBHOOK_USER }}
 
-            - if: ${{ env.IS_SUPABASE_CONFIGURED }} && ${{ env.POSTMARK_WEBHOOK_PASSWORD }}
-              name: 📡 Push supabase postman webhook password secret
+            - if: ${{ env.IS_SUPABASE_CONFIGURED && env.POSTMARK_WEBHOOK_PASSWORD }}
+              name: 📡 Push supabase postmark webhook password secret
               run: |
                   npx supabase secrets set POSTMARK_WEBHOOK_PASSWORD=${{ secrets.POSTMARK_WEBHOOK_PASSWORD }}
 
-            - if: ${{ env.IS_SUPABASE_CONFIGURED }} && ${{ env.POSTMARK_WEBHOOK_AUTHORIZED_IPS }}
-              name: 📡 Push supabase whebhook authorized IPS secret
+            - if: ${{ env.IS_SUPABASE_CONFIGURED && env.POSTMARK_WEBHOOK_AUTHORIZED_IPS }}
+              name: 📡 Push supabase postmark whebhook authorized IPS secret
               run: |
                   npx supabase secrets set POSTMARK_WEBHOOK_AUTHORIZED_IPS=${{ secrets.POSTMARK_WEBHOOK_AUTHORIZED_IPS }}
 


### PR DESCRIPTION
## Problem

Make atomic-crm GitHub workflow pass on forks

## Solution

The deploy job now checks for the secrets presence before launching the supabase setup.
It also list all missing secrets as warning in the job summary

Out of scope: Display an error message in the app when supabase is not properly configured.

## How To Test

- Fork the atomic-crm repository, including the branches.
- Activate github page on the gh-pages branch in settings ([see docs](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-from-a-branch))
- Merge this branch fork on your fork master
- Check the deploy job result
- Check that the gh-page branch has been updated
- Go to the gh page url to check the page has been deployed (https://YourAccountName.github.io/atomic-crm)
    - see a spinner
    - see the error `Uncaught Error: supabaseUrl is required.` in the console
- Set the secrets (You may need to create a supabase account)
- Rerun the deploy job
- return to your gh page
- the app should now run properly

## Additional Checks

- [ ] The **documentation** is up to date
- [ ] Tested with **fakerest** provider (see [related documentation](../doc/data-providers.md))

## Screenshot
Job summary when missing secrets:
![image](https://github.com/user-attachments/assets/3257a1ae-8bc7-4bb1-8ded-69308dd7e305)

