### PR TITLE
Add a build-lib command to be able to publish an atomic-crm node module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,5 @@ supabase/.branches
 supabase/.temp
 
 dist/
+lib/
 .env

--- a/index.html
+++ b/index.html
@@ -121,5 +121,5 @@
             </div>
         </div>
     </body>
-    <script type="module" src="/src/index.tsx"></script>
+    <script type="module" src="/src/script.tsx"></script>
 </html>

--- a/makefile
+++ b/makefile
@@ -25,6 +25,9 @@ stop: stop-supabase ## stop the stack locally
 build: ## build the app
 	npm run build
 
+build-lib: ## build the library
+	npm run build-lib
+
 prod-start: build supabase-deploy
 	open http://127.0.0.1:3000 && npx serve -l tcp://127.0.0.1:3000 dist
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
                 "supabase": "^1.136.3",
                 "typescript": "^5.3.3",
                 "vite": "^5.0.12",
+                "vite-plugin-dts": "^4.2.1",
                 "vitest": "^2.0.5",
                 "web-vitals": "^4.2.2"
             }
@@ -2884,6 +2885,160 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
+        "node_modules/@microsoft/api-extractor": {
+            "version": "7.47.7",
+            "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.47.7.tgz",
+            "integrity": "sha512-fNiD3G55ZJGhPOBPMKD/enozj8yxJSYyVJWxRWdcUtw842rvthDHJgUWq9gXQTensFlMHv2wGuCjjivPv53j0A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@microsoft/api-extractor-model": "7.29.6",
+                "@microsoft/tsdoc": "~0.15.0",
+                "@microsoft/tsdoc-config": "~0.17.0",
+                "@rushstack/node-core-library": "5.7.0",
+                "@rushstack/rig-package": "0.5.3",
+                "@rushstack/terminal": "0.14.0",
+                "@rushstack/ts-command-line": "4.22.6",
+                "lodash": "~4.17.15",
+                "minimatch": "~3.0.3",
+                "resolve": "~1.22.1",
+                "semver": "~7.5.4",
+                "source-map": "~0.6.1",
+                "typescript": "5.4.2"
+            },
+            "bin": {
+                "api-extractor": "bin/api-extractor"
+            }
+        },
+        "node_modules/@microsoft/api-extractor-model": {
+            "version": "7.29.6",
+            "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.29.6.tgz",
+            "integrity": "sha512-gC0KGtrZvxzf/Rt9oMYD2dHvtN/1KPEYsrQPyMKhLHnlVuO/f4AFN3E4toqZzD2pt4LhkKoYmL2H9tX3yCOyRw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@microsoft/tsdoc": "~0.15.0",
+                "@microsoft/tsdoc-config": "~0.17.0",
+                "@rushstack/node-core-library": "5.7.0"
+            }
+        },
+        "node_modules/@microsoft/api-extractor/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@microsoft/api-extractor/node_modules/minimatch": {
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
+            "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/@microsoft/api-extractor/node_modules/semver": {
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@microsoft/api-extractor/node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/@microsoft/api-extractor/node_modules/typescript": {
+            "version": "5.4.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
+            "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "node_modules/@microsoft/api-extractor/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/@microsoft/tsdoc": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.0.tgz",
+            "integrity": "sha512-HZpPoABogPvjeJOdzCOSJsXeL/SMCBgBZMVC3X3d7YYp2gf31MfxhUoYUNwf1ERPJOnQc0wkFn9trqI6ZEdZuA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@microsoft/tsdoc-config": {
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.17.0.tgz",
+            "integrity": "sha512-v/EYRXnCAIHxOHW+Plb6OWuUoMotxTN0GLatnpOb1xq0KuTNw/WI3pamJx/UbsoJP5k9MCw1QxvvhPcF9pH3Zg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@microsoft/tsdoc": "0.15.0",
+                "ajv": "~8.12.0",
+                "jju": "~1.4.0",
+                "resolve": "~1.22.2"
+            }
+        },
+        "node_modules/@microsoft/tsdoc-config/node_modules/ajv": {
+            "version": "8.12.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+            "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/@microsoft/tsdoc-config/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@mui/core-downloads-tracker": {
             "version": "5.16.6",
             "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.16.6.tgz",
@@ -3430,6 +3585,36 @@
                 "node": ">=14.0.0"
             }
         },
+        "node_modules/@rollup/pluginutils": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
+            "integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0",
+                "estree-walker": "^2.0.2",
+                "picomatch": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
             "version": "4.19.2",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.19.2.tgz",
@@ -3448,6 +3633,210 @@
             "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.10.4.tgz",
             "integrity": "sha512-WJgX9nzTqknM393q1QJDJmoW28kUfEnybeTfVNcNAPnIx210RXm2DiXiHzfNPJNIUUb1tJnz/l4QGtJ30PgWmA==",
             "dev": true
+        },
+        "node_modules/@rushstack/node-core-library": {
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.7.0.tgz",
+            "integrity": "sha512-Ff9Cz/YlWu9ce4dmqNBZpA45AEya04XaBFIjV7xTVeEf+y/kTjEasmozqFELXlNG4ROdevss75JrrZ5WgufDkQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "~8.13.0",
+                "ajv-draft-04": "~1.0.0",
+                "ajv-formats": "~3.0.1",
+                "fs-extra": "~7.0.1",
+                "import-lazy": "~4.0.0",
+                "jju": "~1.4.0",
+                "resolve": "~1.22.1",
+                "semver": "~7.5.4"
+            },
+            "peerDependencies": {
+                "@types/node": "*"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rushstack/node-core-library/node_modules/ajv": {
+            "version": "8.13.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
+            "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2",
+                "uri-js": "^4.4.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/@rushstack/node-core-library/node_modules/ajv-draft-04": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+            "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "ajv": "^8.5.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rushstack/node-core-library/node_modules/fs-extra": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+            "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=6 <7 || >=8"
+            }
+        },
+        "node_modules/@rushstack/node-core-library/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@rushstack/node-core-library/node_modules/jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+            "dev": true,
+            "license": "MIT",
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/@rushstack/node-core-library/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@rushstack/node-core-library/node_modules/semver": {
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@rushstack/node-core-library/node_modules/universalify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4.0.0"
+            }
+        },
+        "node_modules/@rushstack/node-core-library/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/@rushstack/rig-package": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.5.3.tgz",
+            "integrity": "sha512-olzSSjYrvCNxUFZowevC3uz8gvKr3WTpHQ7BkpjtRpA3wK+T0ybep/SRUMfr195gBzJm5gaXw0ZMgjIyHqJUow==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "resolve": "~1.22.1",
+                "strip-json-comments": "~3.1.1"
+            }
+        },
+        "node_modules/@rushstack/terminal": {
+            "version": "0.14.0",
+            "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.14.0.tgz",
+            "integrity": "sha512-juTKMAMpTIJKudeFkG5slD8Z/LHwNwGZLtU441l/u82XdTBfsP+LbGKJLCNwP5se+DMCT55GB8x9p6+C4UL7jw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rushstack/node-core-library": "5.7.0",
+                "supports-color": "~8.1.1"
+            },
+            "peerDependencies": {
+                "@types/node": "*"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rushstack/terminal/node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
+        "node_modules/@rushstack/ts-command-line": {
+            "version": "4.22.6",
+            "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.22.6.tgz",
+            "integrity": "sha512-QSRqHT/IfoC5nk9zn6+fgyqOPXHME0BfchII9EUPR19pocsNp/xSbeBCbD3PIR2Lg+Q5qk7OFqk1VhWPMdKHJg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rushstack/terminal": "0.14.0",
+                "@types/argparse": "1.0.38",
+                "argparse": "~1.0.9",
+                "string-argv": "~0.3.1"
+            }
+        },
+        "node_modules/@rushstack/ts-command-line/node_modules/argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "sprintf-js": "~1.0.2"
+            }
         },
         "node_modules/@sec-ant/readable-stream": {
             "version": "0.4.1",
@@ -3663,6 +4052,13 @@
             "peerDependencies": {
                 "@testing-library/dom": ">=7.21.4"
             }
+        },
+        "node_modules/@types/argparse": {
+            "version": "1.0.38",
+            "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
+            "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/aria-query": {
             "version": "5.0.4",
@@ -4361,6 +4757,136 @@
                 "url": "https://opencollective.com/vitest"
             }
         },
+        "node_modules/@volar/language-core": {
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.4.tgz",
+            "integrity": "sha512-kO9k4kTLfxpg+6lq7/KAIv3m2d62IHuCL6GbVgYZTpfKvIGoAIlDxK7pFcB/eczN2+ydg/vnyaeZ6SGyZrJw2w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@volar/source-map": "2.4.4"
+            }
+        },
+        "node_modules/@volar/source-map": {
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.4.tgz",
+            "integrity": "sha512-xG3PZqOP2haG8XG4Pg3PD1UGDAdqZg24Ru8c/qYjYAnmcj6GBR64mstx+bZux5QOyRaJK+/lNM/RnpvBD3489g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@volar/typescript": {
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.4.tgz",
+            "integrity": "sha512-QQMQRVj0fVHJ3XdRKiS1LclhG0VBXdFYlyuHRQF/xLk2PuJuHNWP26MDZNvEVCvnyUQuUQhIAfylwY5TGPgc6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@volar/language-core": "2.4.4",
+                "path-browserify": "^1.0.1",
+                "vscode-uri": "^3.0.8"
+            }
+        },
+        "node_modules/@vue/compiler-core": {
+            "version": "3.5.5",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.5.tgz",
+            "integrity": "sha512-ZrxcY8JMoV+kgDrmRwlDufz0SjDZ7jfoNZiIBluAACMBmgr55o/jTbxnyrccH6VSJXnFaDI4Ik1UFCiq9r8i7w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.25.3",
+                "@vue/shared": "3.5.5",
+                "entities": "^4.5.0",
+                "estree-walker": "^2.0.2",
+                "source-map-js": "^1.2.0"
+            }
+        },
+        "node_modules/@vue/compiler-core/node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@vue/compiler-dom": {
+            "version": "3.5.5",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.5.tgz",
+            "integrity": "sha512-HSvK5q1gmBbxRse3S0Wt34RcKuOyjDJKDDMuF3i7NC+QkDFrbAqw8NnrEm/z7zFDxWZa4/5eUwsBOMQzm1RHBA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vue/compiler-core": "3.5.5",
+                "@vue/shared": "3.5.5"
+            }
+        },
+        "node_modules/@vue/compiler-vue2": {
+            "version": "2.7.16",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-vue2/-/compiler-vue2-2.7.16.tgz",
+            "integrity": "sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "de-indent": "^1.0.2",
+                "he": "^1.2.0"
+            }
+        },
+        "node_modules/@vue/language-core": {
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.1.6.tgz",
+            "integrity": "sha512-MW569cSky9R/ooKMh6xa2g1D0AtRKbL56k83dzus/bx//RDJk24RHWkMzbAlXjMdDNyxAaagKPRquBIxkxlCkg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@volar/language-core": "~2.4.1",
+                "@vue/compiler-dom": "^3.4.0",
+                "@vue/compiler-vue2": "^2.7.16",
+                "@vue/shared": "^3.4.0",
+                "computeds": "^0.0.1",
+                "minimatch": "^9.0.3",
+                "muggle-string": "^0.4.1",
+                "path-browserify": "^1.0.1"
+            },
+            "peerDependencies": {
+                "typescript": "*"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vue/language-core/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/@vue/language-core/node_modules/minimatch": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@vue/shared": {
+            "version": "3.5.5",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.5.tgz",
+            "integrity": "sha512-0KyMXyEgnmFAs6rNUL+6eUHtUCqCaNrVd+AW3MX3LyA0Yry5SA0Km03CDKiOua1x1WWnIr+W9+S0GMFoSDWERQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@zeit/schemas": {
             "version": "2.36.0",
             "resolved": "https://registry.npmjs.org/@zeit/schemas/-/schemas-2.36.0.tgz",
@@ -4426,6 +4952,48 @@
                 "type": "github",
                 "url": "https://github.com/sponsors/epoberezkin"
             }
+        },
+        "node_modules/ajv-formats": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+            "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/ajv-formats/node_modules/ajv": {
+            "version": "8.17.1",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/ansi-align": {
             "version": "3.0.1",
@@ -5535,6 +6103,13 @@
             "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
             "dev": true
         },
+        "node_modules/compare-versions": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+            "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/compressible": {
             "version": "2.0.18",
             "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -5576,10 +6151,24 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         },
+        "node_modules/computeds": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/computeds/-/computeds-0.0.1.tgz",
+            "integrity": "sha512-7CEBgcMjVmitjYo5q8JTJVra6X5mQ20uTThdK+0kR7UEaDrAWEQcRiBtWJzga4eRpP6afNwwLsX2SET2JhVB1Q==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+        },
+        "node_modules/confbox": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.7.tgz",
+            "integrity": "sha512-uJcB/FKZtBMCJpK8MQji6bJHgu1tixKPxRLeGkNzBoOZzpnZUJm0jm2/sBDWcuBx1dYgxV4JU+g5hmNxCyAmdA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/confusing-browser-globals": {
             "version": "1.0.11",
@@ -5860,6 +6449,13 @@
                 "url": "https://github.com/sponsors/kossnocorp"
             }
         },
+        "node_modules/de-indent": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+            "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/debug": {
             "version": "4.3.6",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
@@ -6075,6 +6671,19 @@
             "version": "9.2.2",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
             "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+        },
+        "node_modules/entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
         },
         "node_modules/environment": {
             "version": "1.1.0",
@@ -7008,6 +7617,13 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
         },
+        "node_modules/fast-uri": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.1.tgz",
+            "integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/fast-url-parser": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
@@ -7617,6 +8233,16 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/he": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+            "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "he": "bin/he"
+            }
+        },
         "node_modules/hoist-non-react-statics": {
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -7691,6 +8317,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/import-lazy": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
+            "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/imurmurhash": {
@@ -8576,6 +9212,13 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
+        "node_modules/jju": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+            "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8682,6 +9325,13 @@
             "dependencies": {
                 "json-buffer": "3.0.1"
             }
+        },
+        "node_modules/kolorist": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
+            "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/language-subtag-registry": {
             "version": "0.3.23",
@@ -9035,6 +9685,23 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/local-pkg": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.0.tgz",
+            "integrity": "sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mlly": "^1.4.2",
+                "pkg-types": "^1.0.3"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
             }
         },
         "node_modules/locate-path": {
@@ -9464,10 +10131,30 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/mlly": {
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.1.tgz",
+            "integrity": "sha512-rrVRZRELyQzrIUAVMHxP97kv+G786pHmOKzuFII8zDYahFBS7qnHh2AlYSl1GAHhaMPCz6/oHjVMcfFYgFYHgA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "acorn": "^8.11.3",
+                "pathe": "^1.1.2",
+                "pkg-types": "^1.1.1",
+                "ufo": "^1.5.3"
+            }
+        },
         "node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "node_modules/muggle-string": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+            "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/mute-stream": {
             "version": "1.0.0",
@@ -9910,6 +10597,13 @@
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             }
         },
+        "node_modules/path-browserify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+            "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/path-exists": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -10272,6 +10966,18 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/pkg-types": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.2.0.tgz",
+            "integrity": "sha512-+ifYuSSqOQ8CqP4MbZA5hDpb97n3E8SVWdJe+Wms9kj745lmd3b7EZJiqvmLwAlmRfjrI7Hi5z3kdBJ93lFNPA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "confbox": "^0.1.7",
+                "mlly": "^1.7.1",
+                "pathe": "^1.1.2"
             }
         },
         "node_modules/possible-typed-array-names": {
@@ -11769,6 +12475,13 @@
                 "node": ">= 10.x"
             }
         },
+        "node_modules/sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+            "dev": true,
+            "license": "BSD-3-Clause"
+        },
         "node_modules/stack-utils": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -12452,6 +13165,13 @@
                 "node": ">=14.17"
             }
         },
+        "node_modules/ufo": {
+            "version": "1.5.4",
+            "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.4.tgz",
+            "integrity": "sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/unbox-primitive": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -12669,6 +13389,36 @@
                 "url": "https://opencollective.com/vitest"
             }
         },
+        "node_modules/vite-plugin-dts": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-4.2.1.tgz",
+            "integrity": "sha512-/QlYvgUMiv8+ZTEerhNCYnYaZMM07cdlX6hQCR/w/g/nTh0tUXPoYwbT6SitizLJ9BybT1lnrcZgqheI6wromQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@microsoft/api-extractor": "7.47.7",
+                "@rollup/pluginutils": "^5.1.0",
+                "@volar/typescript": "^2.4.4",
+                "@vue/language-core": "2.1.6",
+                "compare-versions": "^6.1.1",
+                "debug": "^4.3.6",
+                "kolorist": "^1.8.0",
+                "local-pkg": "^0.5.0",
+                "magic-string": "^0.30.11"
+            },
+            "engines": {
+                "node": "^14.18.0 || >=16.0.0"
+            },
+            "peerDependencies": {
+                "typescript": "*",
+                "vite": "*"
+            },
+            "peerDependenciesMeta": {
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/vitest": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.0.5.tgz",
@@ -12827,6 +13577,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/vscode-uri": {
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
+            "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/warning": {
             "version": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "main": "./lib/index.cjs",
     "files": [
         "lib",
-        "README.md"
+        "README.md",
+        "src"
     ],
     "dependencies": {
         "@hello-pangea/dnd": "^16.5.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
     "name": "atomic-crm",
     "version": "0.0.1",
     "type": "module",
-    "module": "src/root/CRM.tsx",
+    "types": "./lib/types",
+    "module": "./lib/index.js",
+    "main": "./lib/index.cjs",
     "dependencies": {
         "@hello-pangea/dnd": "^16.5.0",
         "@mui/icons-material": "^5.15.6",
@@ -59,6 +61,7 @@
         "supabase": "^1.136.3",
         "typescript": "^5.3.3",
         "vite": "^5.0.12",
+        "vite-plugin-dts": "^4.2.1",
         "vitest": "^2.0.5",
         "web-vitals": "^4.2.2"
     },
@@ -66,6 +69,7 @@
         "test": "vitest",
         "dev": "vite --force",
         "build": "tsc && vite build",
+        "build-lib": "tsc && vite build --config vite.lib.config",
         "preview": "vite preview",
         "lint:apply": "eslint **/*.{mjs,ts,tsx} --fix",
         "lint:check": "eslint **/*.{mjs,ts,tsx}",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
     "types": "./lib/types",
     "module": "./lib/index.js",
     "main": "./lib/index.cjs",
-    "files": ["lib", "README.md"],
+    "files": [
+        "lib",
+        "README.md"
+    ],
     "dependencies": {
         "@hello-pangea/dnd": "^16.5.0",
         "@mui/icons-material": "^5.15.6",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "types": "./lib/types",
     "module": "./lib/index.js",
     "main": "./lib/index.cjs",
+    "files": ["lib", "README.md"],
     "dependencies": {
         "@hello-pangea/dnd": "^16.5.0",
         "@mui/icons-material": "^5.15.6",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,18 +1,3 @@
-import React from 'react';
-import { createRoot } from 'react-dom/client';
-import App from './App';
-import reportWebVitals from './reportWebVitals';
+import { CRM } from './root/CRM';
 
-const container = document.getElementById('root');
-const root = createRoot(container!);
-
-root.render(
-    <React.StrictMode>
-        <App />
-    </React.StrictMode>
-);
-
-// If you want to start measuring performance in your app, pass a function
-// to log results (for example: reportWebVitals(console.log))
-// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
-reportWebVitals();
+export default CRM;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,1 @@
-import { CRM } from './root/CRM';
-
-export default CRM;
+export { CRM } from './root/CRM';

--- a/src/script.tsx
+++ b/src/script.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import reportWebVitals from './reportWebVitals';
+
+const container = document.getElementById('root');
+const root = createRoot(container!);
+
+root.render(
+    <React.StrictMode>
+        <App />
+    </React.StrictMode>
+);
+
+// If you want to start measuring performance in your app, pass a function
+// to log results (for example: reportWebVitals(console.log))
+// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
+reportWebVitals();

--- a/vite.lib.config.ts
+++ b/vite.lib.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { visualizer } from 'rollup-plugin-visualizer';
+import dts from 'vite-plugin-dts';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+    plugins: [
+        react(),
+        visualizer({
+            open: process.env.NODE_ENV !== 'CI',
+            filename: './dist/stats.html',
+        }),
+        dts({ include: ['.'], entryRoot: '.', outDir: '../lib/types' }),
+    ],
+    define: {
+        'process.env': process.env,
+    },
+    build: {
+        sourcemap: true,
+        outDir: '../lib',
+
+        emptyOutDir: true,
+        lib: {
+            entry: './index.tsx',
+            fileName: 'index',
+            formats: ['es', 'cjs'],
+        },
+    },
+    resolve: {
+        preserveSymlinks: true,
+    },
+    root: './src',
+});


### PR DESCRIPTION
## Problem

We cannot install atomic-crm from npm

## Solution

Add a lib build along the current app build with:
- esm 
- cjs
- types

## How To Test

To test without actually publishing the module:
- run npm pack to create an archive
- create a npm project, aor use an existing one
- add `"atomic-crm": "file://path-to-the-archive/atomic-crm-0.0.1.tgc"`
- run npm install
- start to play with the atomic-crm library
- Admire the type
- switch your project type between module and commonjs to use both version.
Note: only the CRM component is exposed for now 

## Additional Checks

- [ ] The **documentation** is up to date
- [ ] Tested with **fakerest** provider (see [related documentation](../doc/data-providers.md))
