### PR TITLE
Improve documentation about initial production setup

### DIFF
--- a/doc/developer/deploy.md
+++ b/doc/developer/deploy.md
@@ -4,13 +4,13 @@
 
 The entire backend of Atomic CRM is hosted on Supabase. The backend is composed of a Postgres database, a REST API, and edge functions. Check out the [Supabase Configuration](./supabase-configuration.md) section for details.
 
-After configuring your Supabase instance, you can deploy the backend changes with the following command:
+After [configuring your Supabase instance](./supabase-configuration.md), you can deploy the backend changes with the following command:
 
 ```sh
 make supabase-deploy
 ```
 
-Make sure you access the frontend once to initialize the main admin account. See [Testing Production Mode](#testing-production-mode).
+Make sure you access the frontend once to initialize the main admin account.
 
 ## Testing Production Mode
 

--- a/doc/developer/deploy.md
+++ b/doc/developer/deploy.md
@@ -10,6 +10,8 @@ After configuring your Supabase instance, you can deploy the backend changes wit
 make supabase-deploy
 ```
 
+Make sure you access the frontend once to initialize the main admin account. See [Testing Production Mode](#testing-production-mode).
+
 ## Testing Production Mode
 
 If you want to test you local frontend code using the remote Supabase instance and the production settings, you can run the following command:

--- a/doc/developer/supabase-configuration.md
+++ b/doc/developer/supabase-configuration.md
@@ -56,6 +56,8 @@ To do so, call the following command:
 make prod-start
 ```
 
+You will be prompted to create the first production user.
+
 Using a remote Supabase instance can be interesting if you deploy from your computer, or if you want to test your app with production data in production mode.
 
 ## Email Provider Setup


### PR DESCRIPTION
## Problem

After deploying the supabase instance, it's unclear whether one should invite initial users through the supabase dashboard

## Solution

Improve the deploy documentation to explain how to do the initial setup