### PR TITLE
Update url for inbound-email-configuration

### DIFF
--- a/doc/user/inbound-email.md
+++ b/doc/user/inbound-email.md
@@ -4,7 +4,7 @@ Atomic CRM can receive inbound emails and automatically create or update contact
 
 ## Setup
 
-You must setup Postmark and Supabase to use the inbound email feature. Check the [Inbound Email Setup](./developer/inbound-email.md) documentation for more information.
+You must setup Postmark and Supabase to use the inbound email feature. Check the [Inbound Email Setup](../developer/inbound-email-configuration.md) documentation for more information.
 
 ## Usage
 


### PR DESCRIPTION
Looks like the file structure changed - so updating this reference.

## Problem

URL reference is broken

## Solution

Fixes the url reference

## How To Test

Navigate to the inbound-email.md
Click on the Inbound Email Setup Link

## Additional Checks

- [x] The **documentation** is up to date
- [ ] Tested with **fakerest** provider (see [related documentation](../doc/data-providers.md))

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/atomic-crm#contributing).