### PR TITLE
Fix New Task dialog closes even if task is invalid

### DIFF
--- a/src/tasks/AddTask.tsx
+++ b/src/tasks/AddTask.tsx
@@ -188,12 +188,8 @@ export const AddTask = ({
                             </Stack>
                         </DialogContent>
                         <DialogActions sx={{ p: 0 }}>
-                            <Toolbar
-                                sx={{
-                                    width: '100%',
-                                }}
-                            >
-                                <SaveButton onClick={() => setOpen(false)} />
+                            <Toolbar sx={{ width: '100%' }}>
+                                <SaveButton />
                             </Toolbar>
                         </DialogActions>
                     </Form>


### PR DESCRIPTION
Closes #84

## Problem

New Task dialog closes even if task is invalid

## Solution

The dialog is closed on click on the save button. It should only be closed when the mutation is successful. 

