### PR TITLE
Allow TS sourcemaps in production

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,72 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { visualizer } from 'rollup-plugin-visualizer';
+import path from 'node:path';
+
+const alias = [
+    {
+        find: 'react-admin',
+        replacement: path.resolve(__dirname, './node_modules/react-admin/src'),
+    },
+    {
+        find: 'ra-core',
+        replacement: path.resolve(__dirname, './node_modules/ra-core/src'),
+    },
+    {
+        find: 'ra-i18n-polyglot',
+        replacement: path.resolve(
+            __dirname,
+            './node_modules/ra-i18n-polyglot/src'
+        ),
+    },
+    {
+        find: 'ra-language-english',
+        replacement: path.resolve(
+            __dirname,
+            './node_modules/ra-language-english/src'
+        ),
+    },
+    {
+        find: 'ra-ui-materialui',
+        replacement: path.resolve(
+            __dirname,
+            './node_modules/ra-ui-materialui/src'
+        ),
+    },
+    {
+        find: 'ra-data-fakerest',
+        replacement: path.resolve(
+            __dirname,
+            './node_modules/ra-data-fakerest/src'
+        ),
+    },
+    {
+        find: 'ra-supabase-core',
+        replacement: path.resolve(
+            __dirname,
+            './node_modules/ra-supabase-core/src'
+        ),
+    },
+    {
+        find: 'ra-supabase-ui-materialui',
+        replacement: path.resolve(
+            __dirname,
+            './node_modules/ra-supabase-ui-materialui/src'
+        ),
+    },
+    {
+        find: 'ra-supabase-language-english',
+        replacement: path.resolve(
+            __dirname,
+            './node_modules/ra-supabase-language-english/src'
+        ),
+    },
+    {
+        find: 'ra-supabase',
+        replacement: path.resolve(__dirname, './node_modules/ra-supabase/src'),
+    },
+    // add any other react-admin packages you have
+];
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -22,6 +88,7 @@ export default defineConfig({
         sourcemap: true,
     },
     resolve: {
+        alias,
         preserveSymlinks: true,
     },
 });


### PR DESCRIPTION
## Problem

Debugging in production is hard with transpiled sources

## Solution

Enable TS sourcemap in production as explained at https://marmelab.com/react-admin/Vite.html#sourcemaps-in-production

## How To Test

- `make build`
- `npm run preview`
- check that all react-admin related packages load their files from their `src` directory