### PR TITLE
[CHORE] - adjust UI contact component search input, icon contact filter

### DIFF
--- a/src/atomic-crm/contacts/ContactListFilter.tsx
+++ b/src/atomic-crm/contacts/ContactListFilter.tsx
@@ -105,7 +105,7 @@ export const ContactListFilter = () => {
           ))}
       </FilterCategory>
 
-      <FilterCategory icon={<CheckSquare className="h-4 w-4" />} label="Tasks">
+      <FilterCategory icon={<CheckSquare />} label="Tasks">
         <ToggleFilterButton
           className="w-full justify-between"
           label={"With pending tasks"}
@@ -114,7 +114,7 @@ export const ContactListFilter = () => {
       </FilterCategory>
 
       <FilterCategory
-        icon={<Users className="h-4 w-4" />}
+        icon={<Users />}
         label="Account Manager"
       >
         <ToggleFilterButton

--- a/src/components/admin/search-input.tsx
+++ b/src/components/admin/search-input.tsx
@@ -14,7 +14,7 @@ export const SearchInput = (inProps: SearchInputProps) => {
   }
 
   return (
-    <div className="flex flex-grow relative mt-auto w-full">
+    <div className="flex flex-grow relative mt-auto">
       <TextInput
         label={false}
         helperText={false}

--- a/src/components/admin/search-input.tsx
+++ b/src/components/admin/search-input.tsx
@@ -14,7 +14,7 @@ export const SearchInput = (inProps: SearchInputProps) => {
   }
 
   return (
-    <div className="flex flex-grow relative mt-auto w-fit">
+    <div className="flex flex-grow relative mt-auto w-full">
       <TextInput
         label={false}
         helperText={false}

--- a/src/components/admin/search-input.tsx
+++ b/src/components/admin/search-input.tsx
@@ -1,9 +1,10 @@
 import { useTranslate } from "ra-core";
 import { Search } from "lucide-react";
 import { TextInput, type TextInputProps } from "@/components/admin/text-input";
+import { cn } from "@/lib/utils";
 
 export const SearchInput = (inProps: SearchInputProps) => {
-  const { label, ...rest } = inProps;
+  const { label, className, ...rest } = inProps;
 
   const translate = useTranslate();
 
@@ -19,6 +20,8 @@ export const SearchInput = (inProps: SearchInputProps) => {
         label={false}
         helperText={false}
         placeholder={translate("ra.action.search")}
+        className={cn("flex-grow", className)}
+        inputClassName="pr-8"
         {...rest}
       />
       <Search className="absolute right-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />

--- a/src/components/admin/text-input.tsx
+++ b/src/components/admin/text-input.tsx
@@ -17,6 +17,7 @@ import { InputHelperText } from "@/components/admin/input-helper-text";
 
 export type TextInputProps = InputProps & {
   multiline?: boolean;
+  inputClassName?: string;
 } & React.ComponentProps<"textarea"> &
   React.ComponentProps<"input">;
 
@@ -27,6 +28,7 @@ export const TextInput = (props: TextInputProps) => {
     source,
     multiline,
     className,
+    inputClassName,
     validate: _validateProp,
     format: _formatProp,
     ...rest
@@ -54,9 +56,19 @@ export const TextInput = (props: TextInputProps) => {
       )}
       <FormControl>
         {multiline ? (
-          <Textarea {...rest} {...field} value={value} />
+          <Textarea
+            {...rest}
+            {...field}
+            value={value}
+            className={inputClassName}
+          />
         ) : (
-          <Input {...rest} {...field} value={value} />
+          <Input
+            {...rest}
+            {...field}
+            value={value}
+            className={inputClassName}
+          />
         )}
       </FormControl>
       <InputHelperText helperText={props.helperText} />


### PR DESCRIPTION
Closes https://github.com/marmelab/atomic-crm/issues/106

## Problem

I found that the placeholder text overlaps with the search icon in the contact input field.
Additionally, the contact sidebar icons are inconsistent in their width and height.
- Search Input
<img width="454" height="161" alt="Screenshot 2025-09-29 at 14 55 28" src="https://github.com/user-attachments/assets/75184097-1b4b-4c44-a07b-583fde52dc38" />

- Icon Contact Filter
<img width="278" height="206" alt="Screenshot 2025-09-29 at 15 42 43" src="https://github.com/user-attachments/assets/99a67dff-f650-42b7-9520-5956d513757d" />


## Solution

* Changed `w-fit` to `w-full` in the `search-input` component to prevent the placeholder from overlapping with the search icon.
* Removed fixed `width` and `height` attributes on the sidebar contact icons to ensure consistent sizing with the existing icons.

## How To Test

1. Navigate to the **Contacts** section.
2. Verify that the search input placeholder no longer overlaps with the search icon.
3. Check the contact sidebar icons to confirm that their width and height are now consistent with each other.

## Additional Checks

* [ ] The **documentation** is up to date
* [ ] Tested with **fakerest** provider (see [[related documentation](https://github.com/marmelab/atomic-crm/blob/main/doc/developer/data-providers.md)](https://github.com/marmelab/atomic-crm/blob/main/doc/developer/data-providers.md))

Also, please make sure to read the [[contributing guidelines](https://github.com/marmelab/atomic-crm#contributing)](https://github.com/marmelab/atomic-crm#contributing).