### PR TITLE
Doc: Add getting started link to menu and fix logo size

### DIFF
--- a/doc/astro.config.mjs
+++ b/doc/astro.config.mjs
@@ -78,11 +78,15 @@ export default defineConfig({
       ],
       sidebar: [
         {
-          label: "Users",
+          label: "Getting Started",
+          link: "/",
+        },
+        {
+          label: "Users Documentation",
           autogenerate: { directory: "users" },
         },
         {
-          label: "Developers",
+          label: "Developers Documentation",
           autogenerate: { directory: "developers" },
         },
       ],

--- a/doc/src/content/docs/index.mdx
+++ b/doc/src/content/docs/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Welcome to Atomic CRM
+title: Getting Started
 description: Atomic CRM is designed to be easy to customize and extend by developers with basic React and SQL skills.
 ---
 

--- a/doc/src/styles/global.css
+++ b/doc/src/styles/global.css
@@ -34,6 +34,10 @@
   color: var(--color-black);
 }
 
+.title-wrapper img {
+  @apply size-8;
+}
+
 img.icon {
   display: inline;
   box-shadow: none;

--- a/makefile
+++ b/makefile
@@ -84,4 +84,4 @@ doc-preview: doc-build
 	@(cd doc && npm run preview)
 
 doc-deploy:
-	@(cd doc && npx gh-pages -d dist -e doc -b gh-pages -m "Deploy docs" -a)
+	@(cd doc && npx gh-pages -d dist -e doc -b gh-pages -m "Deploy docs" --remove doc)


### PR DESCRIPTION
- Add Getting Started to menu
- Update logo size
- Update home title

<img width="1919" height="924" alt="Capture d’écran du 2025-10-08 09-44-50" src="https://github.com/user-attachments/assets/8370262e-8c0f-4dff-b5e4-aa71a2ddcf57" />

## How To Test

`make doc-dev`

## Additional Checks

- [X] The **documentation** is up to date
- [ ] Tested with **fakerest** provider (see [related documentation](https://github.com/marmelab/atomic-crm/blob/main/doc/developer/data-providers.md))
