### PR TITLE
feat: add Product, DealProduct, CompanyMachine, ServiceContract TypeScript types

### DIFF
--- a/src/components/atomic-crm/types.ts
+++ b/src/components/atomic-crm/types.ts
@@ -226,3 +226,56 @@ export interface ContactGender {
   label: string;
   icon: ComponentType<{ className?: string }>;
 }
+
+export type Product = {
+  id: number;
+  created_at: string;
+  reference: string;
+  name: string;
+  type:
+    | "thermique"
+    | "electrique"
+    | "robot"
+    | "autoportee"
+    | "accessoires"
+    | string;
+  price: number | null;
+  description: string | null;
+  active: boolean;
+  sales_id: number | null;
+};
+
+export type DealProduct = {
+  id: number;
+  deal_id: number;
+  product_id: number;
+  quantity: number;
+  unit_price: number | null;
+};
+
+export type CompanyMachine = {
+  id: number;
+  created_at: string;
+  company_id: number;
+  product_id: number;
+  serial_number: string | null;
+  purchase_date: string | null;
+  deal_id: number | null;
+  notes: string | null;
+};
+
+export type ServiceContract = {
+  id: number;
+  created_at: string;
+  name: string;
+  company_id: number | null;
+  contact_ids: number[];
+  deal_id: number | null;
+  machine_ids: number[];
+  start_date: string;
+  renewal_date: string;
+  amount: number | null;
+  notes: string | null;
+  status: "actif" | "a-renouveler" | "resilier";
+  sales_id: number | null;
+};


### PR DESCRIPTION
## Summary

- Add `Product` type for machine/product catalog entries
- Add `DealProduct` type for linking products to deals with quantity and pricing
- Add `CompanyMachine` type for tracking installed machines at customer sites
- Add `ServiceContract` type for maintenance/service agreements with typed status enum

## Test plan

- [ ] `make typecheck` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)