### PR TITLE
feat: add service_contracts resource with renewal tracking

### DIFF
--- a/src/components/atomic-crm/root/CRM.tsx
+++ b/src/components/atomic-crm/root/CRM.tsx
@@ -30,6 +30,7 @@ import {
   getDataProvider as defaultDataProviderBuilder,
 } from "../providers/supabase";
 import sales from "../sales";
+import serviceContracts from "../service-contracts";
 import { SettingsPageMobile } from "../settings/SettingsPageMobile";
 import { ProfilePage } from "../settings/ProfilePage";
 import { SettingsPage } from "../settings/SettingsPage";
@@ -270,6 +271,7 @@ const DesktopAdmin = (
       <Resource name="deal_notes" />
       <Resource name="tasks" />
       <Resource name="sales" {...sales} />
+      <Resource name="service_contracts" {...serviceContracts} />
       <Resource name="tags" />
     </Admin>
   );

--- a/src/components/atomic-crm/service-contracts/ServiceContractCreate.tsx
+++ b/src/components/atomic-crm/service-contracts/ServiceContractCreate.tsx
@@ -1,0 +1,34 @@
+import { CreateBase, Form, useGetIdentity } from "ra-core";
+import { Card, CardContent } from "@/components/ui/card";
+import { CancelButton } from "@/components/admin/cancel-button";
+import { SaveButton } from "@/components/admin/form";
+
+import { ServiceContractInputs } from "./ServiceContractInputs";
+
+export const ServiceContractCreate = () => {
+  const { identity } = useGetIdentity();
+  return (
+    <CreateBase redirect="show">
+      <div className="mt-2 flex">
+        <div className="flex-1">
+          <Form defaultValues={{ sales_id: identity?.id }}>
+            <Card>
+              <CardContent>
+                <ServiceContractInputs />
+                <div
+                  role="toolbar"
+                  className="sticky flex pt-4 pb-4 md:pb-0 bottom-0 bg-linear-to-b from-transparent to-card to-10% flex-row justify-end gap-2"
+                >
+                  <CancelButton />
+                  <SaveButton label="Créer le contrat" />
+                </div>
+              </CardContent>
+            </Card>
+          </Form>
+        </div>
+      </div>
+    </CreateBase>
+  );
+};
+
+export default ServiceContractCreate;

--- a/src/components/atomic-crm/service-contracts/ServiceContractEdit.tsx
+++ b/src/components/atomic-crm/service-contracts/ServiceContractEdit.tsx
@@ -1,0 +1,22 @@
+import { EditBase, Form } from "ra-core";
+import { Card, CardContent } from "@/components/ui/card";
+
+import { FormToolbar } from "../layout/FormToolbar";
+import { ServiceContractInputs } from "./ServiceContractInputs";
+
+export const ServiceContractEdit = () => (
+  <EditBase redirect="show">
+    <div className="mt-2 flex">
+      <Form className="flex flex-1 flex-col gap-4 pb-2">
+        <Card>
+          <CardContent>
+            <ServiceContractInputs />
+            <FormToolbar />
+          </CardContent>
+        </Card>
+      </Form>
+    </div>
+  </EditBase>
+);
+
+export default ServiceContractEdit;

--- a/src/components/atomic-crm/service-contracts/ServiceContractInputs.tsx
+++ b/src/components/atomic-crm/service-contracts/ServiceContractInputs.tsx
@@ -1,0 +1,27 @@
+import { required } from "ra-core";
+import { AutocompleteInput } from "@/components/admin/autocomplete-input";
+import { DateInput } from "@/components/admin/date-input";
+import { NumberInput } from "@/components/admin/number-input";
+import { ReferenceInput } from "@/components/admin/reference-input";
+import { SelectInput } from "@/components/admin/select-input";
+import { TextInput } from "@/components/admin/text-input";
+
+import { STATUS_CHOICES } from "./contractUtils";
+
+export const ServiceContractInputs = () => (
+  <div className="flex flex-col gap-4 p-1">
+    <TextInput source="name" validate={required()} />
+    <ReferenceInput source="company_id" reference="companies">
+      <AutocompleteInput optionText="name" validate={required()} />
+    </ReferenceInput>
+    <DateInput source="start_date" validate={required()} />
+    <DateInput source="renewal_date" validate={required()} />
+    <NumberInput source="amount" step={0.01} label="Montant annuel (€)" />
+    <SelectInput
+      source="status"
+      choices={STATUS_CHOICES}
+      defaultValue="actif"
+    />
+    <TextInput source="notes" multiline />
+  </div>
+);

--- a/src/components/atomic-crm/service-contracts/ServiceContractList.tsx
+++ b/src/components/atomic-crm/service-contracts/ServiceContractList.tsx
@@ -1,0 +1,62 @@
+import { useRecordContext } from "ra-core";
+import { CreateButton } from "@/components/admin/create-button";
+import { DataTable } from "@/components/admin/data-table";
+import { DateField } from "@/components/admin/date-field";
+import { List } from "@/components/admin/list";
+import { ReferenceField } from "@/components/admin/reference-field";
+import { TextField } from "@/components/admin/text-field";
+import { Badge } from "@/components/ui/badge";
+
+import { TopToolbar } from "../layout/TopToolbar";
+import type { ServiceContract } from "../types";
+import { formatPrice, getStatusLabel, isExpiringSoon } from "./contractUtils";
+
+const ListActions = () => (
+  <TopToolbar>
+    <CreateButton />
+  </TopToolbar>
+);
+
+const AmountField = (_props: { label?: string | boolean }) => {
+  const record = useRecordContext<ServiceContract>();
+  if (!record) return null;
+  return <span>{formatPrice(record.amount)}</span>;
+};
+
+const StatusField = (_props: { label?: string | boolean }) => {
+  const record = useRecordContext<ServiceContract>();
+  if (!record) return null;
+  const expiring = isExpiringSoon(record.renewal_date);
+  return (
+    <Badge variant={expiring ? "destructive" : "default"}>
+      {getStatusLabel(record.status)}
+    </Badge>
+  );
+};
+
+export const ServiceContractList = () => (
+  <List
+    sort={{ field: "renewal_date", order: "ASC" }}
+    actions={<ListActions />}
+  >
+    <DataTable>
+      <DataTable.Col source="name" />
+      <DataTable.Col label="Entreprise">
+        <ReferenceField source="company_id" reference="companies">
+          <TextField source="name" />
+        </ReferenceField>
+      </DataTable.Col>
+      <DataTable.Col source="renewal_date">
+        <DateField source="renewal_date" />
+      </DataTable.Col>
+      <DataTable.Col label="Montant">
+        <AmountField />
+      </DataTable.Col>
+      <DataTable.Col label="Statut">
+        <StatusField />
+      </DataTable.Col>
+    </DataTable>
+  </List>
+);
+
+export default ServiceContractList;

--- a/src/components/atomic-crm/service-contracts/ServiceContractShow.tsx
+++ b/src/components/atomic-crm/service-contracts/ServiceContractShow.tsx
@@ -1,0 +1,91 @@
+import { ShowBase, useShowContext } from "ra-core";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { EditButton } from "@/components/admin/edit-button";
+import { DateField } from "@/components/admin/date-field";
+import { ReferenceField } from "@/components/admin/reference-field";
+import { TextField } from "@/components/admin/text-field";
+
+import { TopToolbar } from "../layout/TopToolbar";
+import type { ServiceContract } from "../types";
+import {
+  daysUntilRenewal,
+  formatPrice,
+  getStatusLabel,
+  isExpiringSoon,
+} from "./contractUtils";
+
+const ShowActions = () => (
+  <TopToolbar>
+    <EditButton />
+  </TopToolbar>
+);
+
+const ServiceContractShowContent = () => {
+  const { record, isPending } = useShowContext<ServiceContract>();
+  if (isPending || !record) return null;
+
+  const days = daysUntilRenewal(record.renewal_date);
+  const expiring = isExpiringSoon(record.renewal_date);
+
+  return (
+    <Card>
+      <CardContent>
+        <div className="flex flex-col gap-4 pt-4">
+          <h2 className="text-2xl font-bold">{record.name}</h2>
+          <div className="flex items-center gap-2">
+            <Badge variant={expiring ? "destructive" : "default"}>
+              {getStatusLabel(record.status)}
+            </Badge>
+            <span className="text-sm text-muted-foreground">
+              {days >= 0
+                ? `Renouvellement dans ${days} jour(s)`
+                : `Expiré depuis ${Math.abs(days)} jour(s)`}
+            </span>
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <p className="text-sm font-medium text-muted-foreground">
+                Entreprise
+              </p>
+              <ReferenceField source="company_id" reference="companies">
+                <TextField source="name" />
+              </ReferenceField>
+            </div>
+            <div>
+              <p className="text-sm font-medium text-muted-foreground">
+                Date de renouvellement
+              </p>
+              <DateField source="renewal_date" />
+            </div>
+            <div>
+              <p className="text-sm font-medium text-muted-foreground">
+                Montant annuel
+              </p>
+              <p>{formatPrice(record.amount)}</p>
+            </div>
+            {record.notes && (
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">
+                  Notes
+                </p>
+                <p>{record.notes}</p>
+              </div>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export const ServiceContractShow = () => (
+  <ShowBase>
+    <ShowActions />
+    <div className="mt-2">
+      <ServiceContractShowContent />
+    </div>
+  </ShowBase>
+);
+
+export default ServiceContractShow;

--- a/src/components/atomic-crm/service-contracts/contractUtils.test.ts
+++ b/src/components/atomic-crm/service-contracts/contractUtils.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  daysUntilRenewal,
+  isExpiringSoon,
+  getStatusLabel,
+} from "./contractUtils";
+
+describe("contractUtils", () => {
+  const FIXED_DATE = new Date("2026-04-09T12:00:00Z");
+
+  beforeEach(() => {
+    vi.setSystemTime(FIXED_DATE);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("daysUntilRenewal", () => {
+    it("returns 30 for a date 30 days in the future", () => {
+      expect(daysUntilRenewal("2026-05-09")).toBe(30);
+    });
+
+    it("returns 0 for today", () => {
+      expect(daysUntilRenewal("2026-04-09")).toBe(0);
+    });
+
+    it("returns -10 for a date 10 days in the past", () => {
+      expect(daysUntilRenewal("2026-03-30")).toBe(-10);
+    });
+  });
+
+  describe("isExpiringSoon", () => {
+    it("returns true when renewal is within 60 days", () => {
+      expect(isExpiringSoon("2026-05-09")).toBe(true); // 30 days away
+    });
+
+    it("returns false when renewal is beyond 60 days", () => {
+      expect(isExpiringSoon("2026-07-15")).toBe(false); // 97 days away
+    });
+
+    it("returns true for past date", () => {
+      expect(isExpiringSoon("2026-03-30")).toBe(true); // -10 days
+    });
+  });
+
+  describe("getStatusLabel", () => {
+    it("returns 'Actif' for 'actif'", () => {
+      expect(getStatusLabel("actif")).toBe("Actif");
+    });
+
+    it("returns 'À renouveler' for 'a-renouveler'", () => {
+      expect(getStatusLabel("a-renouveler")).toBe("À renouveler");
+    });
+
+    it("returns 'Résilié' for 'resilier'", () => {
+      expect(getStatusLabel("resilier")).toBe("Résilié");
+    });
+  });
+});

--- a/src/components/atomic-crm/service-contracts/contractUtils.ts
+++ b/src/components/atomic-crm/service-contracts/contractUtils.ts
@@ -1,0 +1,35 @@
+const STATUS_LABELS: Record<string, string> = {
+  actif: "Actif",
+  "a-renouveler": "À renouveler",
+  resilier: "Résilié",
+};
+
+export const STATUS_CHOICES = Object.entries(STATUS_LABELS).map(
+  ([value, label]) => ({ id: value, name: label }),
+);
+
+export const daysUntilRenewal = (renewalDate: string): number => {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const renewal = new Date(renewalDate);
+  renewal.setHours(0, 0, 0, 0);
+  return Math.round(
+    (renewal.getTime() - today.getTime()) / (1000 * 60 * 60 * 24),
+  );
+};
+
+export const isExpiringSoon = (
+  renewalDate: string,
+  thresholdDays = 60,
+): boolean => daysUntilRenewal(renewalDate) <= thresholdDays;
+
+export const getStatusLabel = (status: string): string =>
+  STATUS_LABELS[status] ?? status;
+
+export const formatPrice = (amount: number | null): string => {
+  if (amount == null) return "—";
+  return new Intl.NumberFormat("fr-FR", {
+    style: "currency",
+    currency: "EUR",
+  }).format(amount);
+};

--- a/src/components/atomic-crm/service-contracts/index.ts
+++ b/src/components/atomic-crm/service-contracts/index.ts
@@ -1,0 +1,15 @@
+import React from "react";
+
+const ServiceContractList = React.lazy(() => import("./ServiceContractList"));
+const ServiceContractCreate = React.lazy(
+  () => import("./ServiceContractCreate"),
+);
+const ServiceContractEdit = React.lazy(() => import("./ServiceContractEdit"));
+const ServiceContractShow = React.lazy(() => import("./ServiceContractShow"));
+
+export default {
+  list: ServiceContractList,
+  create: ServiceContractCreate,
+  edit: ServiceContractEdit,
+  show: ServiceContractShow,
+};


### PR DESCRIPTION
## Summary

- Add `contractUtils.ts` with `daysUntilRenewal`, `isExpiringSoon`, `getStatusLabel`, `STATUS_CHOICES`
- Add `ServiceContractInputs.tsx` with fields: name, company_id, start_date, renewal_date, amount, status, notes
- Add `ServiceContractList`, `ServiceContractCreate`, `ServiceContractEdit`, `ServiceContractShow` components
- List sorted by `renewal_date` ASC with expiry badge (destructive when ≤60 days)
- Register `service_contracts` resource in `CRM.tsx`

## Test plan

- [ ] `make test` passes (contractUtils unit tests)
- [ ] `make typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)