### PR TITLE
fix(e2e): the dismiss toast helper now targets the first 'close' button

### DIFF
--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -206,7 +206,7 @@ const getMenuMethod = ({ page }: { page: Page; isMobile: boolean }) => ({
 
 const dismissToast = async (page: Page, content: string) => {
   await expect(page.getByText(content)).toBeVisible();
-  await page.getByLabel("Close toast").click();
+  await page.getByLabel("Close toast").first().click();
   // Since we are in optimistic UI, dismissing the toast trigger the request to the api linked to the toast message
   await page.waitForLoadState("networkidle");
 };


### PR DESCRIPTION
## Problem

The E2E suite is broken

## Solution

The dismiss toast helper now targets the first 'close' button

## How To Test

Make test-e2e

## Additional Checks

- [X] The **documentation** is up to date
- [X] Tested with **fakerest** provider (see [related documentation](https://github.com/marmelab/atomic-crm/blob/main/doc/developer/data-providers.md))
- [X] Tested with **Mobile** resolution

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/atomic-crm/tree/main?tab=contributing-ov-file#readme).
