### PR TITLE
Bump playwright version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
       "devDependencies": {
         "@eslint/js": "^9.22.0",
         "@inquirer/prompts": "^8.2.0",
-        "@playwright/test": "^1.58.2",
+        "@playwright/test": "^1.60.0",
         "@storybook/react-vite": "^9.1.19",
         "@types/dompurify": "^3.0.5",
         "@types/faker": "^5.5.9",
@@ -103,7 +103,7 @@
         "globals": "^16.3.0",
         "husky": "^9.1.7",
         "pgsql-ast-parser": "^12.0.2",
-        "playwright": "^1.58.2",
+        "playwright": "^1.60.0",
         "prettier": "^3.6.2",
         "shadcn": "^3.5.0",
         "storybook": "^9.1.19",
@@ -5386,13 +5386,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.58.2"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -15066,13 +15066,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -15085,9 +15085,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
   "devDependencies": {
     "@eslint/js": "^9.22.0",
     "@inquirer/prompts": "^8.2.0",
-    "@playwright/test": "^1.58.2",
+    "@playwright/test": "^1.60.0",
     "@storybook/react-vite": "^9.1.19",
     "@types/dompurify": "^3.0.5",
     "@types/faker": "^5.5.9",
@@ -121,7 +121,7 @@
     "globals": "^16.3.0",
     "husky": "^9.1.7",
     "pgsql-ast-parser": "^12.0.2",
-    "playwright": "^1.58.2",
+    "playwright": "^1.60.0",
     "prettier": "^3.6.2",
     "shadcn": "^3.5.0",
     "storybook": "^9.1.19",


### PR DESCRIPTION
## Description

Bump `playwright` and `@playwright/test` to `^1.60.0` to fix `npx playwright install` hanging at 100% during browser extraction on Node 24+.