### PR TITLE
 Chore: allow to commit on other branches than main

### DIFF
--- a/.claude/agents/chat-orchestrator.md
+++ b/.claude/agents/chat-orchestrator.md
@@ -693,19 +693,20 @@ Bash("for b in $(git -C $CLAUDE_PROJECT_DIR for-each-ref --format='%(refname:sho
   empty. (`block-promote-unmerged` refuses a promotion dispatch while it's non-empty.)
 - **Empty** → every developed ticket is on the session branch.
 
-Then promote the session branch to main (both SETUP and COMPLEX) — Stage A only put
-tickets on `session/<SESSION_SHORT_ID>`; nothing has reached `main` yet.
+Then promote the session branch to the base branch — the branch the session was
+forked from (both SETUP and COMPLEX) — Stage A only put tickets on
+`session/<SESSION_SHORT_ID>`; nothing has reached the base branch yet.
 - **≥ 1 ticket reached `DONE`** → dispatch the promotion merger in the
   **foreground** and handle its result inline (do NOT run the Stage 1–3 transitions
   for it):
   ```
   Agent({
     subagent_type: "merger",
-    description: "Promote session branch to main",
+    description: "Promote session branch to base branch",
     prompt: "ROLE: merger\nMODE: promote\nSESSION_SHORT_ID: <SESSION_SHORT_ID>"
   })
   ```
-  - `DONE: PROMOTE commit=…` → the session branch is now on `main`. SETUP path
+  - `DONE: PROMOTE commit=…` → the session branch is now on the base branch. SETUP path
     (planner given `SETUP_MODE=true`) → STATE SETUP-DONE. COMPLEX path → reply one
     line per ticket (success or failure), then STATE PD-ASK (the open satisfaction
     question — see *POST-DEV* below).

--- a/.claude/agents/merger.md
+++ b/.claude/agents/merger.md
@@ -1,6 +1,6 @@
 ---
 name: merger
-description: Local merge agent (no team, single-shot). Dispatch contexts — (1) per-task Stage A merge of a feature branch into the session branch, (2) SIMPLE flow (Stage A then promotion in one shot), (3) promotion-only (Stage B, session branch → main under flock), (4) ROLLBACK (revert branch promoted directly into the default branch). No PR, no CI watch, no SendMessage — purely local git.
+description: Local merge agent (no team, single-shot). Dispatch contexts — (1) per-task Stage A merge of a feature branch into the session branch, (2) SIMPLE flow (Stage A then promotion in one shot), (3) promotion-only (Stage B, session branch → base branch under flock), (4) ROLLBACK (revert branch promoted directly into the base branch). No PR, no CI watch, no SendMessage — purely local git.
 model: haiku
 tools:
   - Bash
@@ -14,14 +14,14 @@ skills: []
 
 ## Role
 
-You move a developer's work toward `main` in two stages, never both at once unless told to:
+You move a developer's work toward the **base branch** (the branch the session was forked from) in two stages, never both at once unless told to:
 
 - **Stage A** — merge a feature branch into the **session branch** (`session/<SESSION_SHORT_ID>`) inside the `_session` worktree.
-- **Stage B (PROMOTION)** — promote the session branch into `main` (in `$CLAUDE_PROJECT_DIR`) under a `flock` lock.
+- **Stage B (PROMOTION)** — promote the session branch into the base branch (in `$CLAUDE_PROJECT_DIR`) under a `flock` lock.
 
 You don't create PRs, push, or watch CI. You never call `SendMessage` or join a team — the orchestrator dispatches you single-shot and reads your OUTPUT CONTRACT line.
 
-There is also a **ROLLBACK** path (rollback-conflict resolution): `simple-developer` produced revert commits on `BRANCH_NAME` (already rebased onto the default branch). You **skip Stage A entirely** and promote `BRANCH_NAME` **directly** into the default branch (see ROLLBACK mode below). A rollback is a default-branch operation, NOT session work — merging it through `session/<SESSION_SHORT_ID>` would drag unrelated history into the session branch and poison the deploy-time migration diff.
+There is also a **ROLLBACK** path (rollback-conflict resolution): `simple-developer` produced revert commits on `BRANCH_NAME` (already rebased onto the base branch). You **skip Stage A entirely** and promote `BRANCH_NAME` **directly** into the base branch (see ROLLBACK mode below). A rollback is a base-branch operation, NOT session work — merging it through `session/<SESSION_SHORT_ID>` would drag unrelated history into the session branch and poison the deploy-time migration diff.
 
 Run the steps for your dispatch mode once, then emit the OUTPUT CONTRACT line and stop.
 
@@ -100,30 +100,40 @@ The orchestrator parses this line by regex. Any other format is treated as `FAIL
 
 ---
 
-### PROMOTION — Stage B (session branch → main)
+### PROMOTION — Stage B (session branch → base branch)
 
 **Trigger**: either `MODE: promote` (COMPLEX, run once per request after every ticket has merged into the session branch) or automatically after Stage A in the SIMPLE flow.
 
-**Promotion ALWAYS targets the repository's default branch** — never trust
-`$CLAUDE_PROJECT_DIR`'s current HEAD. If `$CLAUDE_PROJECT_DIR` has drifted onto a previous session's branch
-(it can, and nothing else resets it), merging into the current HEAD silently
-piles every session onto that branch while the default branch never advances:
-the promotion "succeeds" but the work never reaches the real main. So the lock
-block checks out the default branch first, then merges.
+**Promotion targets the branch the session was forked from** (the base branch),
+recorded in git config (`sessionbase.<SESSION_SHORT_ID>.branch`) by the
+`setup-worktree` hook at the moment of the fork — so the work lands back on the
+branch the user is on, not always on `main`. The recorded value is preferred;
+if absent (e.g. a session started before this was introduced) — or if it names a
+branch that no longer exists locally (deleted or renamed since the fork) — it
+falls back to the repository's remote default branch, then `master`/`main`. Either way, never
+trust `$CLAUDE_PROJECT_DIR`'s current HEAD: if `$CLAUDE_PROJECT_DIR` has drifted
+onto a previous session's branch (it can, and nothing else resets it), merging
+into the current HEAD silently piles every session onto that branch while the
+base branch never advances — the promotion "succeeds" but the work never reaches
+the real base branch. So the lock block resolves the target explicitly and checks
+it out first, then merges.
 
 ```bash
 cd $CLAUDE_PROJECT_DIR && flock $CLAUDE_PROJECT_DIR/.promote.lock bash -c '
-  DEFAULT=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed "s@^origin/@@")
+  DEFAULT=$(git config --get sessionbase.<SESSION_SHORT_ID>.branch 2>/dev/null)
+  # Recorded base deleted/renamed since the fork → discard, fall through to the default chain.
+  [ -n "$DEFAULT" ] && ! git show-ref --verify --quiet "refs/heads/$DEFAULT" && DEFAULT=
+  [ -z "$DEFAULT" ] && DEFAULT=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed "s@^origin/@@")
   [ -z "$DEFAULT" ] && { git show-ref --verify --quiet refs/heads/master && DEFAULT=master || DEFAULT=main; }
   git reset --hard HEAD                       # drop working-tree debris on whatever branch we are on
-  git checkout "$DEFAULT" || exit 1           # promotion target is the default branch, NOT $CLAUDE_PROJECT_DIR HEAD
+  git checkout "$DEFAULT" || exit 1           # promotion target is the session fork-base branch, NOT $CLAUDE_PROJECT_DIR HEAD
   /entrypoint-helpers/apply-app-variant.sh    # checkout reverts App.tsx variant — re-apply it
   git merge --no-ff session/<SESSION_SHORT_ID> -m "merge(session): <SESSION_SHORT_ID>" \
     || { git merge --abort; exit 1; }
 '
 ```
 
-After this block `$CLAUDE_PROJECT_DIR` is left on the default branch (with the promotion
+After this block `$CLAUDE_PROJECT_DIR` is left on the base branch (with the promotion
 merged in), which also keeps the next session's `setup-worktree` fork base
 correct.
 
@@ -135,18 +145,21 @@ correct.
   - SIMPLE: `FAILED: SIMPLE promote conflict: files=[<paths>]`
 
   Do NOT resolve — the orchestrator dispatches a resolver.
-- The `flock` serialises promotions across concurrent sessions sharing main.
+- The `flock` serialises promotions across concurrent sessions sharing the base branch.
 
-### ROLLBACK PROMOTION (ROLLBACK mode — `BRANCH_NAME` → main, no Stage A)
+### ROLLBACK PROMOTION (ROLLBACK mode — `BRANCH_NAME` → base branch, no Stage A)
 
 Identical to Stage B except you merge **`BRANCH_NAME`** instead of the session
 branch, and you never run Stage A. `simple-developer` already rebased the reverts
-onto the default branch, so this merge fast-forwards cleanly unless the default
+onto the base branch, so this merge fast-forwards cleanly unless the base
 branch moved meanwhile.
 
 ```bash
 cd $CLAUDE_PROJECT_DIR && flock $CLAUDE_PROJECT_DIR/.promote.lock bash -c '
-  DEFAULT=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed "s@^origin/@@")
+  DEFAULT=$(git config --get sessionbase.<SESSION_SHORT_ID>.branch 2>/dev/null)
+  # Recorded base deleted/renamed since the fork → discard, fall through to the default chain.
+  [ -n "$DEFAULT" ] && ! git show-ref --verify --quiet "refs/heads/$DEFAULT" && DEFAULT=
+  [ -z "$DEFAULT" ] && DEFAULT=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed "s@^origin/@@")
   [ -z "$DEFAULT" ] && { git show-ref --verify --quiet refs/heads/master && DEFAULT=master || DEFAULT=main; }
   git reset --hard HEAD
   git checkout "$DEFAULT" || exit 1
@@ -165,7 +178,7 @@ cd $CLAUDE_PROJECT_DIR && flock $CLAUDE_PROJECT_DIR/.promote.lock bash -c '
 ### NEVER
 - `git add` / `git commit` / `git stash` / `git clean -fd` (except the ticket-status JSON write in Stage A step 3, via the `node -e` snippet — never the Edit/Write tools).
 - `git push`, `gh` commands, `--no-verify`, `--force`.
-- Force-merge on conflict — abort and report failed. This applies to both Stage A (task branch → session branch) and Stage B (session branch → main).
+- Force-merge on conflict — abort and report failed. This applies to both Stage A (task branch → session branch) and Stage B (session branch → base branch).
 - Resolve conflicts — the merger never resolves conflicts at any stage. Always abort and report.
 - `SendMessage`, spawn agents, `TeamCreate`, `TeamDelete`. You are single-shot, never in a team.
 - Write any file other than the Stage A ticket JSON (step 3).

--- a/.claude/hooks/block-promote-unmerged.mjs
+++ b/.claude/hooks/block-promote-unmerged.mjs
@@ -46,7 +46,7 @@ const describe = ({ branch, count }) =>
   `  - ${branch} (${count === null ? "unmerged (count unavailable)" : `${count} unmerged commit(s)`})`;
 
 ctx.fail(
-  `Refusing to promote ${session} to main — these task branches have commits NOT yet merged into the session branch:\n` +
+  `Refusing to promote ${session} to the base branch — these task branches have commits NOT yet merged into the session branch:\n` +
     unmerged.map(describe).join("\n") +
     "\n" +
     "A ticket was developed but never merged (its reviewers/merger were likely never dispatched). For EACH branch above, drive its ticket through REVIEW -> MERGE (dispatch its quality-reviewer + test-validator if needed, then its per-ticket merger) so its work lands on the session branch. Re-dispatch the promotion merger only once this list is empty.",

--- a/.claude/hooks/setup-worktree.mjs
+++ b/.claude/hooks/setup-worktree.mjs
@@ -150,6 +150,21 @@ if (
   git(["branch", sessionBaseBranch(ctx), base]);
 }
 
+// Record the fork-base branch NAME so promotion (merger Stage B) merges the
+// session's work back into the branch it was forked from — the source branch the
+// user is on — instead of always targeting the repo default (main). The
+// session-base/<short> ref records the fork COMMIT but not the name, so the name
+// is captured here. Written only when missing: that pins the value at fork time
+// and never overwrites it with a later, possibly drifted, $REPO HEAD. The key
+// lives for the whole session — like session/<short> and session-base/<short> it
+// is NOT torn down per request (cleanup-worktree leaves it in place); clean-harness
+// removes it at session teardown. Keyed by session short id (a config subsection,
+// so any short id is valid).
+const baseBranchKey = `sessionbase.${ctx.sessionShort}.branch`;
+if (!git(["config", "--get", baseBranchKey]).stdout.trim()) {
+  git(["config", "--local", baseBranchKey, base]);
+}
+
 if (!existsSync(join(sessionWt, ".git"))) {
   rmSync(sessionWt, { recursive: true, force: true });
   mkdirSync(dirname(sessionWt), { recursive: true });

--- a/scripts/clean-harness.sh
+++ b/scripts/clean-harness.sh
@@ -5,6 +5,7 @@
 # Removes everything the SIMPLE/COMPLEX agent pipeline leaves behind:
 #   - session git worktrees under /tmp/<repo-slug>/
 #   - branches checked out in those worktrees, plus session/* and session-base/*
+#   - the sessionbase.* git config keys recording each session's fork-base branch
 #   - the .promote.lock promotion lock file
 #   - the /tmp/<repo-slug> session directory tree
 #
@@ -12,11 +13,13 @@
 # session worktree.
 #
 # By default it also lands you back where you launched the harness from:
-#   - checks out the branch you started on (the harness checks out main to
-#     promote, which would otherwise strand you there),
+#   - checks out the branch you started on (a safety net, in case the harness or
+#     a drifted session left you on a different branch),
 #   - hard-resets that branch to the pre-harness commit (dropping every commit
-#     the harness made on top),
-#   - restores main to origin/main (undoing the merge the harness made on main).
+#     the harness promoted onto it — promotion now targets the start branch, not
+#     main),
+#   - restores main to origin/main as a backstop (older sessions promoted onto
+#     main; current sessions promote onto the start branch instead).
 #
 # The start branch + commit are read from .git/clean-harness-return, written by
 # launch-harness.sh at launch (it survives the /tmp cleanup). If that record is
@@ -137,6 +140,21 @@ say "==> Deleting session branches..."
     do_run git branch -D "$br"
   fi
 done
+
+# 3b. Remove recorded session fork-base config keys (sessionbase.<short>.branch,
+# written by setup-worktree.mjs and read by the promotion merger). Every session
+# branch is being deleted above, so a stray key would only outlive its branch and
+# accumulate in .git/config. `--get-regexp` exits non-zero with no matches, hence
+# the `|| true` guard under `set -e`.
+say "==> Removing session base-branch config keys..."
+{ git config --local --get-regexp '^sessionbase\.' 2>/dev/null || true; } \
+  | awk '{ sub(/\.branch$/, "", $1); print $1 }' \
+  | sort -u \
+  | while IFS= read -r subsection; do
+      [[ -z "$subsection" ]] && continue
+      say "    - $subsection"
+      do_run git config --local --remove-section "$subsection" 2>/dev/null || true
+    done
 
 # 4. Remove the promotion lock.
 if [[ -f "$REPO_ROOT/.promote.lock" ]]; then


### PR DESCRIPTION
Depends on #307

## Problem

Agents push to main even if the base branch is anothe rone

## Solution

Tell agents to push to their base branch instead of main