### PR TITLE
Fix Logo url invalid during OAuth

### DIFF
--- a/.claude/skills/update-branding/SKILL.md
+++ b/.claude/skills/update-branding/SKILL.md
@@ -21,7 +21,7 @@ Not for theme colors or component styling see `Skill({skill: "shadcn-customizati
 
 Confirm which the user means — most requests mean only #1.
 
-1. **App logo / wordmark** (common) — `public/logos/`. `logo_atomic_crm_dark.svg` is **light-colored** art shown in **dark mode** + all auth pages; `logo_atomic_crm_light.svg` is **dark-colored** art shown in **light mode**. (`logo_atomic_crm.svg` is an unused standalone copy.)
+1. **App logo / wordmark** (common) — `src/components/atomic-crm/root/logos/`, imported as module assets by `defaultConfiguration.ts` (Vite resolves the URL relative to the JS chunk, so it survives nested routes like `/oauth/consent` and sub-path deploys). `logo_atomic_crm_dark.svg` is **light-colored** art shown in **dark mode** + all auth pages; `logo_atomic_crm_light.svg` is **dark-colored** art shown in **light mode**. (A standalone unused `logo_atomic_crm.svg` still lives in `public/logos/`.)
    > Files are named by **the mode they display in**, not their color — the "dark-mode" logo must read on a dark background.
 2. **Favicon + PWA icons** — only if asked. Much bigger (34 PNGs); see [below](#favicon--app-icons-optional).
 
@@ -37,9 +37,9 @@ Confirm which the user means — most requests mean only #1.
 1. **Gather the asset(s).** Ask for the file/URL, format (SVG vs PNG), and whether there are **separate light/dark variants** or one image.
    - One variant → set both config keys to it; **warn** about poor contrast in one theme (auth pages always use the dark-mode key).
    - Single-fill SVG → derive the other variant by swapping the fill (`white` ↔ `black`).
-2. **Place the files** in `public/logos/`:
-   - **Drop-in (simplest):** overwrite `logo_atomic_crm_dark.svg` / `logo_atomic_crm_light.svg`, keeping the exact filenames + `.svg`. Config already points here — done. (SVG only.)
-   - **New name / format (e.g. PNG):** save as new files, then update the two consts in `defaultConfiguration.ts` (`defaultDarkModeLogo`, `defaultLightModeLogo`; paths relative to `public/`, so `"./logos/<file>"`).
+2. **Place the files** in `src/components/atomic-crm/root/logos/`:
+   - **Drop-in (simplest):** overwrite `logo_atomic_crm_dark.svg` / `logo_atomic_crm_light.svg`, keeping the exact filenames + `.svg`. The imports in `defaultConfiguration.ts` already point here — done. (SVG only.)
+   - **New name / format (e.g. PNG):** save as new files next to them, then update the two `import` statements at the top of `defaultConfiguration.ts` (they feed `defaultDarkModeLogo` / `defaultLightModeLogo`; module-relative paths, so `"./logos/<file>"`). Do **not** revert them to bare public-path strings — that reintroduces issue #291.
 3. **Update the title** (if the name changes) in all **three** places — `defaultTitle` drives only the first:
    - `defaultConfiguration.ts` → `defaultTitle` — header `<h1>` + logo `alt`.
    - `index.html` → `<title>` — browser-tab title (hardcoded, not set at runtime).

--- a/doc/src/content/docs/developers/customizing.mdx
+++ b/doc/src/content/docs/developers/customizing.mdx
@@ -65,12 +65,13 @@ export default App;
 | ---------------------- | ------------------------------------------------------------------------------------ | -------------- |
 | `companySectors`       | The list of company sectors used in the application.                                 | LabeledValue[] |
 | `currency`             | The ISO 4217 currency code used to format monetary values (default: `"USD"`).        | string         |
+| `darkModeLogo`         | Logo shown in dark mode and on the auth pages. Use an imported asset, an absolute URL, or a data URI — never a route-relative path (it breaks on nested routes like `/oauth/consent`). | string         |
 | `darkTheme`            | The theme to use when the application is in dark mode.                               | RaThemeOptions |
 | `dealCategories`       | The categories of deals used in the application.                                     | LabeledValue[] |
 | `dealPipelineStatuses` | The statuses of deals in the pipeline used in the application                        | string[]       |
 | `dealStages`           | The stages of deals used in the application.                                         | DealStage[]    |
+| `lightModeLogo`        | Logo shown in light mode. Same rule as `darkModeLogo`: imported asset, absolute URL, or data URI only. | string         |
 | `lightTheme`           | The theme to use when the application is in light mode.                              | RaThemeOptions |
-| `logo`                 | The logo used in the CRM application.                                                | string         |
 | `noteStatuses`         | The statuses of notes used in the application.                                       | NoteStatus[]   |
 | `taskTypes`            | The types of tasks used in the application.                                          | LabeledValue[] |
 | `title`                | The title of the CRM application.                                                    | string         |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,16 +10,23 @@ import { CRM } from "@/components/atomic-crm/root/CRM";
  *  - dealPipelineStatuses
  *  - dealStages
  *  - lightTheme
- *  - logo
+ *  - darkModeLogo / lightModeLogo
  *  - noteStatuses
  *  - taskTypes
  *  - title
  * ... as well as all the props accepted by shadcn-admin-kit's <Admin> component.
  *
+ * Logos must be an imported asset, an absolute URL, or a data URI — never a
+ * route-relative path like "./img/logo.png", which breaks on nested routes.
+ *
  * @example
+ * import logoDark from "./logo-dark.svg";
+ * import logoLight from "./logo-light.svg";
+ *
  * const App = () => (
  *    <CRM
- *       logo="./img/logo.png"
+ *       darkModeLogo={logoDark}
+ *       lightModeLogo={logoLight}
  *       title="Acme CRM"
  *    />
  * );

--- a/src/components/atomic-crm/login/ConfirmationRequired.tsx
+++ b/src/components/atomic-crm/login/ConfirmationRequired.tsx
@@ -13,7 +13,7 @@ export const ConfirmationRequired = () => {
           src={logo}
           alt={title}
           width={24}
-          className="filter brightness-0 invert"
+          className="filter brightness-0 dark:invert"
         />
         <h1 className="text-xl font-semibold">{title}</h1>
       </div>

--- a/src/components/atomic-crm/login/SignupPage.tsx
+++ b/src/components/atomic-crm/login/SignupPage.tsx
@@ -102,7 +102,7 @@ export const SignupPage = () => {
           src={logo}
           alt={title}
           width={24}
-          className="filter brightness-0 invert"
+          className="filter brightness-0 dark:invert"
         />
         <h1 className="text-xl font-semibold">{title}</h1>
       </div>

--- a/src/components/atomic-crm/root/CRM.tsx
+++ b/src/components/atomic-crm/root/CRM.tsx
@@ -86,7 +86,8 @@ export type CRMProps = {
  * @param {string[]} dealPipelineStatuses - The statuses of deals in the pipeline used in the application.
  * @param {DealStage[]} dealStages - The stages of deals used in the application.
  * @param {RaThemeOptions} lightTheme - The theme to use when the application is in light mode.
- * @param {string} logo - The logo used in the CRM application.
+ * @param {string} darkModeLogo - Logo shown in dark mode and on the auth pages. Must be an imported asset, an absolute URL, or a data URI — never a route-relative path like "./logos/x.svg", which breaks on nested routes such as /oauth/consent (issue #291).
+ * @param {string} lightModeLogo - Logo shown in light mode. Same rule as darkModeLogo: imported asset, absolute URL, or data URI only.
  * @param {NoteStatus[]} noteStatuses - The statuses of notes used in the application.
  * @param {LabeledValue[]} taskTypes - The types of tasks used in the application.
  * @param {string} title - The title of the CRM application.
@@ -99,7 +100,8 @@ export type CRMProps = {
  *
  * const App = () => (
  *     <CRM
- *         logo="/path/to/logo.png"
+ *         darkModeLogo="https://example.com/logo-dark.svg"
+ *         lightModeLogo="https://example.com/logo-light.svg"
  *         title="My Custom CRM"
  *         lightTheme={{
  *             ...defaultTheme,

--- a/src/components/atomic-crm/root/defaultConfiguration.ts
+++ b/src/components/atomic-crm/root/defaultConfiguration.ts
@@ -1,7 +1,12 @@
 import type { ConfigurationContextValue } from "./ConfigurationContext";
+// Import the logos as module assets so Vite resolves their URL relative to the
+// JS chunk (import.meta.url), not the current route. A plain "./logos/..." path
+// breaks on nested routes like /oauth/consent and under a deployment sub-path.
+import darkModeLogo from "./logos/logo_atomic_crm_dark.svg";
+import lightModeLogo from "./logos/logo_atomic_crm_light.svg";
 
-export const defaultDarkModeLogo = "./logos/logo_atomic_crm_dark.svg";
-export const defaultLightModeLogo = "./logos/logo_atomic_crm_light.svg";
+export const defaultDarkModeLogo = darkModeLogo;
+export const defaultLightModeLogo = lightModeLogo;
 
 export const defaultCurrency = "USD";
 


### PR DESCRIPTION
Image URLs use relative paths, which isn't compatible with all the ways the logo can be customized (via string in CRM, via configuration, and via settings page). Switching to absolute paths is the only solution and works in all cases.

Closes #291

